### PR TITLE
Make improvements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ matrix:
     - image: Visual Studio 2015
 
 build_script:
-  - set CC=gcc && set FT_LIBBLAS=openblas && set FT_FFTW_WITH_COMBINED_THREADS=1
+  - set CC=gcc && set FT_BLAS=openblas && set FT_FFTW_WITH_COMBINED_THREADS=1
   - gcc --version
   - mingw32-make lib
   - mingw32-make tests

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ matrix:
     - image: Visual Studio 2015
 
 build_script:
-  - set CC=gcc && set FT_FFTW_WITH_COMBINED_THREADS=1
+  - set CC=gcc && set FT_LIBBLAS=openblas && set FT_FFTW_WITH_COMBINED_THREADS=1
   - gcc --version
   - mingw32-make lib
   - mingw32-make tests

--- a/Make.inc
+++ b/Make.inc
@@ -29,13 +29,13 @@ endif
 
 CFLAGS += -std=gnu99 -Ofast -march=native -mtune=native -mno-vzeroupper -I./src
 
-ifeq ($(FT_USE_PREDEFINED_LIBRARIES), 1)
+ifdef FT_PREFIX
     ifeq ($(UNAME), Windows)
-        CFLAGS += -I$(prefix)\include
-        LDFLAGS += -L$(prefix)\bin
+        CFLAGS += -I$(FT_PREFIX)\include
+        LDFLAGS += -L$(FT_PREFIX)\bin
     else
-        CFLAGS += -I$(prefix)/include
-        LDFLAGS += -L$(prefix)/lib
+        CFLAGS += -I$(FT_PREFIX)/include
+        LDFLAGS += -L$(FT_PREFIX)/lib
     endif
 else
     ifeq ($(UNAME), Darwin)
@@ -59,11 +59,11 @@ else
     endif
 endif
 
-ifndef FT_LIBBLAS
-    FT_LIBBLAS = blas
+ifndef FT_BLAS
+    FT_BLAS = blas
 endif
 
-LDLIBS += -fopenmp -lm -lquadmath -lmpfr -l$(FT_LIBBLAS) -lfftw3
+LDLIBS += -fopenmp -lm -lquadmath -lmpfr -l$(FT_BLAS) -lfftw3
 
 ifneq ($(FT_FFTW_WITH_COMBINED_THREADS), 1)
     LDLIBS += -lfftw3_threads

--- a/Make.inc
+++ b/Make.inc
@@ -1,6 +1,6 @@
 LIB = fasttransforms
 LIBDIR = .
-LIBFLAGS = -shared -lm -fPIC
+LIBFLAGS = -shared -fPIC
 
 ifeq ($(OS), Windows_NT)
     UNAME := Windows
@@ -56,7 +56,6 @@ else
         CFLAGS += -Ic:\tools\vcpkg\installed\x64-windows\include\openblas
         CFLAGS += -Ic:\tools\vcpkg\installed\x64-windows\include
         LDFLAGS += -Lc:\tools\vcpkg\installed\x64-windows\bin
-        LDFLAGS += -L.
     endif
 endif
 
@@ -64,7 +63,7 @@ ifndef FT_LIBBLAS
     FT_LIBBLAS = blas
 endif
 
-LDLIBS += -fopenmp -lquadmath -lmpfr -l$(FT_LIBBLAS) -lfftw3
+LDLIBS += -fopenmp -lm -lquadmath -lmpfr -l$(FT_LIBBLAS) -lfftw3
 
 ifneq ($(FT_FFTW_WITH_COMBINED_THREADS), 1)
     LDLIBS += -lfftw3_threads

--- a/Make.inc
+++ b/Make.inc
@@ -30,8 +30,13 @@ endif
 CFLAGS += -std=gnu99 -Ofast -march=native -mtune=native -mno-vzeroupper -I./src
 
 ifeq ($(FT_USE_PREDEFINED_LIBRARIES), 1)
-    CFLAGS += -I$(prefix)/include
-    LDFLAGS += -L$(prefix)/lib
+    ifeq ($(UNAME), Windows)
+        CFLAGS += -I$(prefix)\include
+        LDFLAGS += -L$(prefix)\bin
+    else
+        CFLAGS += -I$(prefix)/include
+        LDFLAGS += -L$(prefix)/lib
+    endif
 else
     ifeq ($(UNAME), Darwin)
         ifeq ($(FT_USE_APPLEBLAS), 1)
@@ -55,17 +60,12 @@ else
     endif
 endif
 
-LDLIBS += -lm -lquadmath -fopenmp -lfftw3
+ifndef FT_LIBBLAS
+    FT_LIBBLAS = blas
+endif
+
+LDLIBS += -fopenmp -lquadmath -lmpfr -l$(FT_LIBBLAS) -lfftw3
 
 ifneq ($(FT_FFTW_WITH_COMBINED_THREADS), 1)
     LDLIBS += -lfftw3_threads
-endif
-
-LDLIBS += -lmpfr
-ifeq ($(UNAME), Linux)
-    LDLIBS += -lgmp -lblas
-else ifeq ($(UNAME), Darwin)
-    LDLIBS += -lgmp -lblas
-else ifeq ($(OS), Windows_NT)
-    LDLIBS += -lmpir -lopenblas
 endif

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The library makes use of OpenBLAS, FFTW3, and MPFR, which are easily installed v
 Apple's version of GCC does not support OpenMP. Sample installation:
 ```
 brew install gcc@8 fftw mpfr
-export CC=gcc-8 && export FT_USE_APPLEBLAS=1 && make
+make CC=gcc-8 FT_USE_APPLEBLAS=1
 ```
 On macOS, the OpenBLAS dependency is optional in light of the vecLib framework. In case the library is compiled with vecLib, then the environment variable `VECLIB_MAXIMUM_THREADS` partially controls the multithreading.
 
@@ -26,7 +26,8 @@ On macOS, the OpenBLAS dependency is optional in light of the vecLib framework. 
 To access functions from the library, you must ensure that you append the current library path to the default. Sample installation:
 ```
 apt-get install gcc-8 libblas-dev libopenblas-base libfftw3-dev libmpfr-dev
-export CC=gcc-8 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:. && make
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:.
+make CC=gcc-8
 ```
 See the [Travis build](https://github.com/MikaelSlevinsky/FastTransforms/blob/master/.travis.yml) for further details.
 
@@ -35,7 +36,7 @@ See the [Travis build](https://github.com/MikaelSlevinsky/FastTransforms/blob/ma
 We use GCC 7.2.0 distributed through MinGW-w64 on Visual Studio 2017. Sample installation:
 ```
 vcpkg install openblas:x64-windows fftw3[core,threads]:x64-windows mpir:x64-windows mpfr:x64-windows
-set CC=gcc && set FT_FFTW_WITH_COMBINED_THREADS=1 && mingw32-make
+mingw32-make CC=gcc FT_LIBBLAS=openblas FT_FFTW_WITH_COMBINED_THREADS=1
 ```
 See the [AppVeyor build](https://github.com/MikaelSlevinsky/FastTransforms/blob/master/.appveyor.yml) for further details.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See the [Travis build](https://github.com/MikaelSlevinsky/FastTransforms/blob/ma
 We use GCC 7.2.0 distributed through MinGW-w64 on Visual Studio 2017. Sample installation:
 ```
 vcpkg install openblas:x64-windows fftw3[core,threads]:x64-windows mpir:x64-windows mpfr:x64-windows
-mingw32-make CC=gcc FT_LIBBLAS=openblas FT_FFTW_WITH_COMBINED_THREADS=1
+mingw32-make CC=gcc FT_BLAS=openblas FT_FFTW_WITH_COMBINED_THREADS=1
 ```
 See the [AppVeyor build](https://github.com/MikaelSlevinsky/FastTransforms/blob/master/.appveyor.yml) for further details.
 


### PR DESCRIPTION
- Add `FT_BLAS` to define the BLAS library for linkage. Fallback is `blas`.
- Shorten `FT_USE_PREDEFINED_LIBRARIES` to `FT_PREFIX`
- Link to math only once
- No need to literally link to gmp or mpir for mpfr (provided mpfr can find them)
