### PR TITLE
Ofast-to-O3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ script:
   - ./test_hierarchical
   - ./test_banded
   - ./test_dprk
-  #- ./test_tdc
+  - ./test_tdc
   - OMP_NUM_THREADS=4 ./test_drivers 3 3 0
   - OMP_NUM_THREADS=4 ./test_fftw 3 3 0
   - make examples

--- a/Make.inc
+++ b/Make.inc
@@ -46,11 +46,12 @@ OBJ = src/transforms.c src/rotations.c src/permute.c src/tdc.c src/drivers.c src
 machine := $(shell $(CC) -dumpmachine | cut -d'-' -f1)
 
 ifndef CFLAGS
+    CFLAGS = -O3
     ifneq (, $(findstring 86, $(machine)))
-        CFLAGS = -march=native -mtune=native -mno-vzeroupper
+        CFLAGS += -march=native -mtune=native -mno-vzeroupper
     endif
 endif
-CFLAGS += -Ofast -std=gnu99 -I./src
+CFLAGS += -std=gnu99 -I./src
 
 ifdef FT_PREFIX
     CFLAGS += -I$(FT_PREFIX)/include


### PR DESCRIPTION
-Ofast enables -ffast-math, which ignores strict IEEE compliance. This affects the global state for denormal numbers through DAZ (denormals-are-zero) and FTZ (flush-to-zero).
With -fno-protect-parens as well, -Ofast overly aggressively optimizes flops in definitions such as

static FLT X(diff)(FLT x, FLT y) {return x - y;}

resulting in the failure of test_tdc for the past while. It should be possible to reactivate this test now.