### PR TITLE
Feat cleanup code

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ install:
   - set PATH=c:\tools\vcpkg\installed\x64-windows\bin;%PATH%
 
 build_script:
-  - set CC=gcc && set FT_BLAS=openblas && set FT_FFTW_WITH_COMBINED_THREADS=1
+  - set CC=gcc && set FT_QUADMATH=1 && set FT_BLAS=openblas && set FT_FFTW_WITH_COMBINED_THREADS=1
   - gcc --version
   - mingw32-make assembly
   - mingw32-make lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,57 +13,57 @@ jobs:
           packages: ['libomp', 'openblas', 'fftw', 'mpfr']
       env: JOBS_EVAL=""
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       compiler: gcc-4.9
       addons:
         homebrew:
-          packages: ['gcc@4.9', 'fftw', 'mpfr']
+          packages: ['gcc@4.9', 'openblas', 'fftw', 'mpfr']
           update: true
-      env: JOBS_EVAL="export CC=gcc-4.9 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
+      env: JOBS_EVAL="export CC=gcc-4.9 && export FT_QUADMATH=1"
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       compiler: gcc-5
       addons:
         homebrew:
-          packages: ['gcc@5', 'fftw', 'mpfr']
+          packages: ['gcc@5', 'openblas', 'fftw', 'mpfr']
           update: true
-      env: JOBS_EVAL="export CC=gcc-5 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
+      env: JOBS_EVAL="export CC=gcc-5 && export FT_QUADMATH=1"
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       compiler: gcc-6
       addons:
         homebrew:
-          packages: ['gcc@6', 'fftw', 'mpfr']
+          packages: ['gcc@6', 'openblas', 'fftw', 'mpfr']
           update: true
-      env: JOBS_EVAL="export CC=gcc-6 && export FT_QUADMATH=1 && export COV=gcov-6 && export FT_COVERAGE=1 && export FT_USE_APPLEBLAS=1"
+      env: JOBS_EVAL="export CC=gcc-6 && export FT_QUADMATH=1 && export COV=gcov-6 && export FT_COVERAGE=1"
       after_success:
         - make coverage
         - bash <(curl -s https://codecov.io/bash)
     # Recommended system requirements
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       compiler: gcc-7
       addons:
         homebrew:
-          packages: ['gcc@7', 'fftw', 'mpfr']
+          packages: ['gcc@7', 'openblas', 'fftw', 'mpfr']
           update: true
-      env: JOBS_EVAL="export CC=gcc-7 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
+      env: JOBS_EVAL="export CC=gcc-7 && export FT_QUADMATH=1"
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       compiler: gcc-8
       addons:
         homebrew:
-          packages: ['gcc@8', 'fftw', 'mpfr']
+          packages: ['gcc@8', 'openblas', 'fftw', 'mpfr']
           update: true
-      env: JOBS_EVAL="export CC=gcc-8 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
+      env: JOBS_EVAL="export CC=gcc-8 && export FT_QUADMATH=1"
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       compiler: gcc-9
       addons:
         homebrew:
-          packages: ['gcc@9', 'fftw', 'mpfr']
+          packages: ['gcc@9', 'openblas', 'fftw', 'mpfr']
           update: true
-      env: JOBS_EVAL="export CC=gcc-9 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
+      env: JOBS_EVAL="export CC=gcc-9 && export FT_QUADMATH=1"
     # Minimum system requirements
     - os: linux
       compiler: gcc-4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,8 @@ jobs:
       addons:
         homebrew:
           packages: ['libomp', 'openblas', 'fftw', 'mpfr']
-      env: JOBS_EVAL="export CC=clang && export COV=gcov && export FT_COVERAGE=1"
-      after_success:
-        - make coverage
-        - bash <(curl -s https://codecov.io/bash)
-      os: osx
+      env: JOBS_EVAL="export CC=clang"
+    - os: osx
       osx_image: xcode11
       compiler: gcc
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ jobs:
           sources: ubuntu-toolchain-r-test
           packages: ['libomp-dev', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
       env: JOBS_EVAL="export CC=clang && export COV=gcov && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+      after_success:
+        - make coverage
+        - bash <(curl -s https://codecov.io/bash)
     - os: linux
       compiler: gcc
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jobs:
     - stage: "Test"
     # Minimum system requirements
       os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       compiler: clang
       addons:
         homebrew:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,51 +21,22 @@ jobs:
       env: JOBS_EVAL="export CC=gcc"
     # Minimum system requirements
     - os: linux
-      compiler: gcc-4.9
+      compiler: clang
       addons:
         apt:
           sources: ubuntu-toolchain-r-test
-          packages: ['gcc-4.9', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc-4.9 && export FT_QUADMATH=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+          packages: ['libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
+      env: JOBS_EVAL="export CC=clang && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
     - os: linux
-      compiler: gcc-5
+      compiler: gcc
       addons:
         apt:
           sources: ubuntu-toolchain-r-test
-          packages: ['gcc-5', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc-5 && export FT_QUADMATH=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
-    - os: linux
-      compiler: gcc-6
-      addons:
-        apt:
-          sources: ubuntu-toolchain-r-test
-          packages: ['gcc-6', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc-6 && export FT_QUADMATH=1 && export COV=gcov-6 && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+          packages: ['libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
+      env: JOBS_EVAL="export CC=gcc && export FT_QUADMATH=1 && export COV=gcov && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
       after_success:
         - make coverage
         - bash <(curl -s https://codecov.io/bash)
-    # Recommended system requirements
-    - os: linux
-      compiler: gcc-7
-      addons:
-        apt:
-          sources: ubuntu-toolchain-r-test
-          packages: ['gcc-7', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc-7 && export FT_QUADMATH=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
-    - os: linux
-      compiler: gcc-8
-      addons:
-        apt:
-          sources: ubuntu-toolchain-r-test
-          packages: ['gcc-8', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc-8 && export FT_QUADMATH=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
-    - os: linux
-      compiler: gcc-9
-      addons:
-        apt:
-          sources: ubuntu-toolchain-r-test
-          packages: ['gcc-9', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc-9 && export FT_QUADMATH=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
     - stage: "Documentation"
       os: osx
       osx_image: xcode11

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,20 @@ jobs:
     # Minimum system requirements
       os: osx
       osx_image: xcode10
+      compiler: clang
+      addons:
+        homebrew:
+          packages: ['libomp', 'fftw', 'mpfr']
+          update: true
+      env: JOBS_EVAL="export FT_USE_APPLEBLAS=1"
+    - os: osx
+      osx_image: xcode10
       compiler: gcc-4.9
       addons:
         homebrew:
           packages: ['gcc@4.9', 'fftw', 'mpfr']
           update: true
-      env: JOBS_EVAL="export CC=gcc-4.9 && export FT_USE_APPLEBLAS=1"
+      env: JOBS_EVAL="export CC=gcc-4.9 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
     - os: osx
       osx_image: xcode10
       compiler: gcc-5
@@ -20,7 +28,7 @@ jobs:
         homebrew:
           packages: ['gcc@5', 'fftw', 'mpfr']
           update: true
-      env: JOBS_EVAL="export CC=gcc-5 && export FT_USE_APPLEBLAS=1"
+      env: JOBS_EVAL="export CC=gcc-5 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
     - os: osx
       osx_image: xcode10
       compiler: gcc-6
@@ -28,7 +36,7 @@ jobs:
         homebrew:
           packages: ['gcc@6', 'fftw', 'mpfr']
           update: true
-      env: JOBS_EVAL="export CC=gcc-6 && export COV=gcov-6 && export FT_COVERAGE=1 && export FT_USE_APPLEBLAS=1"
+      env: JOBS_EVAL="export CC=gcc-6 && export FT_QUADMATH=1 && export COV=gcov-6 && export FT_COVERAGE=1 && export FT_USE_APPLEBLAS=1"
       after_success:
         - make coverage
         - bash <(curl -s https://codecov.io/bash)
@@ -40,7 +48,7 @@ jobs:
         homebrew:
           packages: ['gcc@7', 'fftw', 'mpfr']
           update: true
-      env: JOBS_EVAL="export CC=gcc-7 && export FT_USE_APPLEBLAS=1"
+      env: JOBS_EVAL="export CC=gcc-7 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
     - os: osx
       osx_image: xcode10
       compiler: gcc-8
@@ -48,7 +56,7 @@ jobs:
         homebrew:
           packages: ['gcc@8', 'fftw', 'mpfr']
           update: true
-      env: JOBS_EVAL="export CC=gcc-8 && export FT_USE_APPLEBLAS=1"
+      env: JOBS_EVAL="export CC=gcc-8 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
     - os: osx
       osx_image: xcode10
       compiler: gcc-9
@@ -56,7 +64,7 @@ jobs:
         homebrew:
           packages: ['gcc@9', 'fftw', 'mpfr']
           update: true
-      env: JOBS_EVAL="export CC=gcc-9 && export FT_USE_APPLEBLAS=1"
+      env: JOBS_EVAL="export CC=gcc-9 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
     # Minimum system requirements
     - os: linux
       compiler: gcc-4.9
@@ -64,21 +72,21 @@ jobs:
         apt:
           sources: ubuntu-toolchain-r-test
           packages: ['gcc-4.9', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc-4.9 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+      env: JOBS_EVAL="export CC=gcc-4.9 && export FT_QUADMATH=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
     - os: linux
       compiler: gcc-5
       addons:
         apt:
           sources: ubuntu-toolchain-r-test
           packages: ['gcc-5', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc-5 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+      env: JOBS_EVAL="export CC=gcc-5 && export FT_QUADMATH=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
     - os: linux
       compiler: gcc-6
       addons:
         apt:
           sources: ubuntu-toolchain-r-test
           packages: ['gcc-6', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc-6 && export COV=gcov-6 && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+      env: JOBS_EVAL="export CC=gcc-6 && export FT_QUADMATH=1 && export COV=gcov-6 && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
       after_success:
         - make coverage
         - bash <(curl -s https://codecov.io/bash)
@@ -89,21 +97,21 @@ jobs:
         apt:
           sources: ubuntu-toolchain-r-test
           packages: ['gcc-7', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc-7 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+      env: JOBS_EVAL="export CC=gcc-7 && export FT_QUADMATH=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
     - os: linux
       compiler: gcc-8
       addons:
         apt:
           sources: ubuntu-toolchain-r-test
           packages: ['gcc-8', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc-8 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+      env: JOBS_EVAL="export CC=gcc-8 && export FT_QUADMATH=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
     - os: linux
       compiler: gcc-9
       addons:
         apt:
           sources: ubuntu-toolchain-r-test
           packages: ['gcc-9', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc-9 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+      env: JOBS_EVAL="export CC=gcc-9 && export FT_QUADMATH=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
     - stage: "Documentation"
       os: osx
       osx_image: xcode10

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,53 +11,20 @@ jobs:
       addons:
         homebrew:
           packages: ['libomp', 'openblas', 'fftw', 'mpfr']
-      env: JOBS_EVAL=""
-    - os: osx
-      osx_image: xcode11
-      compiler: gcc-4.9
-      addons:
-        homebrew:
-          packages: ['gcc@4.9', 'openblas', 'fftw', 'mpfr']
-      env: JOBS_EVAL="export CC=gcc-4.9 && export FT_QUADMATH=1"
-    - os: osx
-      osx_image: xcode11
-      compiler: gcc-5
-      addons:
-        homebrew:
-          packages: ['gcc@5', 'openblas', 'fftw', 'mpfr']
-      env: JOBS_EVAL="export CC=gcc-5 && export FT_QUADMATH=1"
-    - os: osx
-      osx_image: xcode11
-      compiler: gcc-6
-      addons:
-        homebrew:
-          packages: ['gcc@6', 'openblas', 'fftw', 'mpfr']
-      env: JOBS_EVAL="export CC=gcc-6 && export FT_QUADMATH=1 && export COV=gcov-6 && export FT_COVERAGE=1"
+      env: JOBS_EVAL="export CC=clang && export COV=gcov && export FT_COVERAGE=1"
       after_success:
         - make coverage
         - bash <(curl -s https://codecov.io/bash)
-    # Recommended system requirements
-    - os: osx
+      os: osx
       osx_image: xcode11
-      compiler: gcc-7
+      compiler: gcc
       addons:
         homebrew:
-          packages: ['gcc@7', 'openblas', 'fftw', 'mpfr']
-      env: JOBS_EVAL="export CC=gcc-7 && export FT_QUADMATH=1"
-    - os: osx
-      osx_image: xcode11
-      compiler: gcc-8
-      addons:
-        homebrew:
-          packages: ['gcc@8', 'openblas', 'fftw', 'mpfr']
-      env: JOBS_EVAL="export CC=gcc-8 && export FT_QUADMATH=1"
-    - os: osx
-      osx_image: xcode11
-      compiler: gcc-9
-      addons:
-        homebrew:
-          packages: ['gcc@9', 'openblas', 'fftw', 'mpfr']
-      env: JOBS_EVAL="export CC=gcc-9 && export FT_QUADMATH=1"
+          packages: ['libomp', 'openblas', 'fftw', 'mpfr']
+      env: JOBS_EVAL="export CC=gcc && export COV=gcov && export FT_COVERAGE=1"
+      after_success:
+        - make coverage
+        - bash <(curl -s https://codecov.io/bash)
     # Minimum system requirements
     - os: linux
       compiler: gcc-4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,14 @@ jobs:
     - stage: "Test"
     # Minimum system requirements
       os: osx
-      osx_image: xcode11
+      osx_image: xcode10
       compiler: clang
       addons:
         homebrew:
           packages: ['libomp', 'fftw', 'mpfr']
       env: JOBS_EVAL="export FT_USE_APPLEBLAS=1"
     - os: osx
-      osx_image: xcode11
+      osx_image: xcode10
       compiler: gcc-4.9
       addons:
         homebrew:
@@ -21,7 +21,7 @@ jobs:
           update: true
       env: JOBS_EVAL="export CC=gcc-4.9 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
     - os: osx
-      osx_image: xcode11
+      osx_image: xcode10
       compiler: gcc-5
       addons:
         homebrew:
@@ -29,7 +29,7 @@ jobs:
           update: true
       env: JOBS_EVAL="export CC=gcc-5 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
     - os: osx
-      osx_image: xcode11
+      osx_image: xcode10
       compiler: gcc-6
       addons:
         homebrew:
@@ -41,7 +41,7 @@ jobs:
         - bash <(curl -s https://codecov.io/bash)
     # Recommended system requirements
     - os: osx
-      osx_image: xcode11
+      osx_image: xcode10
       compiler: gcc-7
       addons:
         homebrew:
@@ -49,7 +49,7 @@ jobs:
           update: true
       env: JOBS_EVAL="export CC=gcc-7 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
     - os: osx
-      osx_image: xcode11
+      osx_image: xcode10
       compiler: gcc-8
       addons:
         homebrew:
@@ -57,7 +57,7 @@ jobs:
           update: true
       env: JOBS_EVAL="export CC=gcc-8 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
     - os: osx
-      osx_image: xcode11
+      osx_image: xcode10
       compiler: gcc-9
       addons:
         homebrew:
@@ -113,7 +113,7 @@ jobs:
       env: JOBS_EVAL="export CC=gcc-9 && export FT_QUADMATH=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
     - stage: "Documentation"
       os: osx
-      osx_image: xcode11
+      osx_image: xcode10
       addons:
         homebrew:
           packages: doxygen

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,7 @@ jobs:
       addons:
         homebrew:
           packages: ['libomp', 'openblas', 'fftw', 'mpfr']
-      env: JOBS_EVAL="export CC=gcc && export COV=gcov && export FT_COVERAGE=1"
-      after_success:
-        - make coverage
-        - bash <(curl -s https://codecov.io/bash)
+      env: JOBS_EVAL="export CC=gcc"
     # Minimum system requirements
     - os: linux
       compiler: gcc-4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jobs:
     - stage: "Test"
     # Minimum system requirements
       os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       compiler: clang
       addons:
         homebrew:
@@ -14,7 +14,7 @@ jobs:
           update: true
       env: JOBS_EVAL="export FT_USE_APPLEBLAS=1"
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       compiler: gcc-4.9
       addons:
         homebrew:
@@ -22,7 +22,7 @@ jobs:
           update: true
       env: JOBS_EVAL="export CC=gcc-4.9 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       compiler: gcc-5
       addons:
         homebrew:
@@ -30,7 +30,7 @@ jobs:
           update: true
       env: JOBS_EVAL="export CC=gcc-5 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       compiler: gcc-6
       addons:
         homebrew:
@@ -42,7 +42,7 @@ jobs:
         - bash <(curl -s https://codecov.io/bash)
     # Recommended system requirements
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       compiler: gcc-7
       addons:
         homebrew:
@@ -50,7 +50,7 @@ jobs:
           update: true
       env: JOBS_EVAL="export CC=gcc-7 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       compiler: gcc-8
       addons:
         homebrew:
@@ -58,7 +58,7 @@ jobs:
           update: true
       env: JOBS_EVAL="export CC=gcc-8 && export FT_QUADMATH=1 && export FT_USE_APPLEBLAS=1"
     - os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       compiler: gcc-9
       addons:
         homebrew:
@@ -114,7 +114,7 @@ jobs:
       env: JOBS_EVAL="export CC=gcc-9 && export FT_QUADMATH=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
     - stage: "Documentation"
       os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       addons:
         homebrew:
           packages: doxygen

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: c
 jobs:
   include:
     - stage: "Test"
-    # Minimum system requirements
       os: osx
       osx_image: xcode11
       compiler: clang
@@ -19,14 +18,13 @@ jobs:
         homebrew:
           packages: ['libomp', 'openblas', 'fftw', 'mpfr']
       env: JOBS_EVAL="export CC=gcc"
-    # Minimum system requirements
     - os: linux
       compiler: clang
       addons:
         apt:
           sources: ubuntu-toolchain-r-test
           packages: ['libomp-dev', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=clang && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+      env: JOBS_EVAL="export CC=clang && export COV=gcov && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
     - os: linux
       compiler: gcc
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
       addons:
         apt:
           sources: ubuntu-toolchain-r-test
-          packages: ['libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
+          packages: ['libomp-dev', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
       env: JOBS_EVAL="export CC=clang && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
     - os: linux
       compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ jobs:
       compiler: clang
       addons:
         homebrew:
-          packages: ['libomp', 'fftw', 'mpfr']
-      env: JOBS_EVAL="export FT_USE_APPLEBLAS=1"
+          packages: ['libomp', 'openblas', 'fftw', 'mpfr']
+      env: JOBS_EVAL=""
     - os: osx
       osx_image: xcode10
       compiler: gcc-4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ jobs:
       addons:
         homebrew:
           packages: ['gcc@4.9', 'openblas', 'fftw', 'mpfr']
-          update: true
       env: JOBS_EVAL="export CC=gcc-4.9 && export FT_QUADMATH=1"
     - os: osx
       osx_image: xcode11
@@ -26,7 +25,6 @@ jobs:
       addons:
         homebrew:
           packages: ['gcc@5', 'openblas', 'fftw', 'mpfr']
-          update: true
       env: JOBS_EVAL="export CC=gcc-5 && export FT_QUADMATH=1"
     - os: osx
       osx_image: xcode11
@@ -34,7 +32,6 @@ jobs:
       addons:
         homebrew:
           packages: ['gcc@6', 'openblas', 'fftw', 'mpfr']
-          update: true
       env: JOBS_EVAL="export CC=gcc-6 && export FT_QUADMATH=1 && export COV=gcov-6 && export FT_COVERAGE=1"
       after_success:
         - make coverage
@@ -46,7 +43,6 @@ jobs:
       addons:
         homebrew:
           packages: ['gcc@7', 'openblas', 'fftw', 'mpfr']
-          update: true
       env: JOBS_EVAL="export CC=gcc-7 && export FT_QUADMATH=1"
     - os: osx
       osx_image: xcode11
@@ -54,7 +50,6 @@ jobs:
       addons:
         homebrew:
           packages: ['gcc@8', 'openblas', 'fftw', 'mpfr']
-          update: true
       env: JOBS_EVAL="export CC=gcc-8 && export FT_QUADMATH=1"
     - os: osx
       osx_image: xcode11
@@ -62,7 +57,6 @@ jobs:
       addons:
         homebrew:
           packages: ['gcc@9', 'openblas', 'fftw', 'mpfr']
-          update: true
       env: JOBS_EVAL="export CC=gcc-9 && export FT_QUADMATH=1"
     # Minimum system requirements
     - os: linux
@@ -113,11 +107,10 @@ jobs:
       env: JOBS_EVAL="export CC=gcc-9 && export FT_QUADMATH=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
     - stage: "Documentation"
       os: osx
-      osx_image: xcode10
+      osx_image: xcode11
       addons:
         homebrew:
           packages: doxygen
-          update: true
       script: doxygen Doxyfile
       deploy:
         - provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,7 @@ jobs:
         apt:
           sources: ubuntu-toolchain-r-test
           packages: ['libomp-dev', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=clang && export COV=gcov && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
-      after_success:
-        - make coverage
-        - bash <(curl -s https://codecov.io/bash)
+      env: JOBS_EVAL="export CC=clang && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
     - os: linux
       compiler: gcc
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ jobs:
       addons:
         homebrew:
           packages: ['libomp', 'fftw', 'mpfr']
-          update: true
       env: JOBS_EVAL="export FT_USE_APPLEBLAS=1"
     - os: osx
       osx_image: xcode11

--- a/Make.inc
+++ b/Make.inc
@@ -136,7 +136,13 @@ ifndef FT_BLAS
     FT_BLAS = blas
 endif
 
-LDLIBS += -Xpreprocessor -fopenmp -lomp -lm -lmpfr -l$(FT_BLAS) -lfftw3
+ifneq (, $(findstring Apple LLVM version, $(shell $(CC) --version)))
+    FOPENMP := -Xpreprocessor -fopenmp -lomp
+else
+    FOPENMP := -fopenmp
+endif
+
+LDLIBS += $(FOPENMP) -lm -lmpfr -l$(FT_BLAS) -lfftw3
 
 ifdef FT_QUADMATH
     CFLAGS += -DFT_QUADMATH

--- a/Make.inc
+++ b/Make.inc
@@ -36,21 +36,21 @@ endif
 
 simd := $(shell $(CC) -march=native -E -v - </dev/null 2>&1 | grep cc1)
 
-ifneq (, $(findstring msse, $(simd)))
+ifneq (, $(filter -msse +sse, $(simd)))
     MSSE := -msse
 endif
-ifneq (, $(findstring msse2, $(simd)))
+ifneq (, $(filter -msse2 +sse2, $(simd)))
     MSSE2 := -msse2
 endif
-ifneq (, $(findstring mavx, $(simd)))
+ifneq (, $(filter -mavx +avx, $(simd)))
     MAVX := -mavx
 endif
-ifneq (, $(findstring mfma, $(simd)))
-    ifeq (, $(findstring mfma4, $(simd)))
+ifneq (, $(filter -mfma +fma, $(simd)))
+    ifeq (, $(filter -mfma4 +fma4, $(simd)))
         MFMA := -mfma
     endif
 endif
-ifneq (, $(findstring mavx512f, $(simd)))
+ifneq (, $(filter -mavx512f +avx512f, $(simd)))
     ifneq ($(UNAME), Windows)
         MAVX512F := -mavx512f
     endif
@@ -85,7 +85,7 @@ SRC = src/recurrence.c src/transforms.c src/rotations.c src/permute.c src/tdc.c 
 
 machine := $(shell $(CC) -dumpmachine | cut -d'-' -f1)
 
-AFLAGS += -O3 -fPIC -std=gnu99 -I./src
+AFLAGS += -O3 -fPIC -std=gnu11 -I./src
 
 ifndef CFLAGS
     CFLAGS = -O3
@@ -93,7 +93,7 @@ ifndef CFLAGS
         CFLAGS += -march=native
     endif
 endif
-CFLAGS += -std=gnu99 -I./src
+CFLAGS += -std=gnu11 -I./src
 
 ifeq ($(FT_COVERAGE), 1)
     CFLAGS += -coverage
@@ -136,7 +136,12 @@ ifndef FT_BLAS
     FT_BLAS = blas
 endif
 
-LDLIBS += -fopenmp -lm -lquadmath -lmpfr -l$(FT_BLAS) -lfftw3
+LDLIBS += -Xpreprocessor -fopenmp -lomp -lm -lmpfr -l$(FT_BLAS) -lfftw3
+
+ifdef FT_QUADMATH
+    CFLAGS += -DFT_QUADMATH
+    LDLIBS += -lquadmath
+endif
 
 ifneq ($(FT_FFTW_WITH_COMBINED_THREADS), 1)
     LDLIBS += -lfftw3_threads

--- a/Make.inc
+++ b/Make.inc
@@ -138,6 +138,8 @@ endif
 
 ifneq (, $(findstring Apple LLVM version, $(shell $(CC) --version)))
     FOPENMP := -Xpreprocessor -fopenmp -lomp
+else ifneq (, $(findstring Apple clang version, $(shell $(CC) --version)))
+    FOPENMP := -Xpreprocessor -fopenmp -lomp
 else
     FOPENMP := -fopenmp
 endif

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ See the [AppVeyor build](https://github.com/MikaelSlevinsky/FastTransforms/blob/
 
 The tables below shows the current timings and accuracies for the transforms with pseudorandom coefficients drawn from U(-1,1) and converted back. The timings are reported in seconds and the error is measured in the relative 2- and ∞-norms.
 
-The library is compiled by GNU GCC 8.3.0 as above with the compiler optimization flags `-O3 -march=native`, and executed on an iMac Pro (Early 2018) with a 2.3 GHz Intel Xeon W-2191B processor with 18 threads on 18 logical cores.
+The library is compiled by Apple LLVM version 10.0.1 as above with the compiler optimization flags `-O3 -march=native`, and executed on an iMac Pro (Early 2018) with a 2.3 GHz Intel Xeon W-2191B processor with 18 threads on 18 logical cores.
 
 ### Spherical harmonic series to bivariate Fourier series (`sph2fourier`)
 
 | Degree            | 63       | 127      | 255      | 511      | 1023     | 2047     | 4095     | 8191     |
 | ----------------: | -------: | -------: | -------: | -------: | -------: | -------: | -------: | -------: |
-| **Forward**       | 0.000159 | 0.000540 | 0.001852 | 0.005510 | 0.022874 | 0.120082 | 0.786019 | 4.902573 |
-| **Backward**      | 0.000159 | 0.000555 | 0.001852 | 0.005501 | 0.023940 | 0.119339 | 0.778569 | 4.939324 |
+| **Forward**       | 0.000101 | 0.000446 | 0.001952 | 0.006277 | 0.026590 | 0.141962 | 0.775724 | 4.870621 |
+| **Backward**      | 0.000101 | 0.000448 | 0.001918 | 0.006357 | 0.027123 | 0.145149 | 0.815881 | 5.040577 |
 | **ϵ<sub>2</sub>** | 5.42e-16 | 7.79e-16 | 9.23e-16 | 1.27e-15 | 1.80e-15 | 2.52e-15 | 3.54e-15 | 4.98e-15 |
 | **ϵ<sub>∞</sub>** | 1.33e-15 | 2.55e-15 | 4.55e-15 | 5.22e-15 | 9.33e-15 | 1.11e-14 | 1.81e-14 | 3.80e-14 |
 
@@ -59,8 +59,8 @@ The library is compiled by GNU GCC 8.3.0 as above with the compiler optimization
 
 | Degree            | 63       | 127      | 255      | 511      | 1023     | 2047     | 4095     | 8191     |
 | ----------------: | -------: | -------: | -------: | -------: | -------: | -------: | -------: | -------: |
-| **Forward**       | 0.000128 | 0.000313 | 0.000969 | 0.003482 | 0.015711 | 0.093525 | 0.638155 | 4.591086 |
-| **Backward**      | 0.000125 | 0.000302 | 0.000948 | 0.003543 | 0.016041 | 0.094016 | 0.670728 | 4.420676 |
+| **Forward**       | 0.000063 | 0.000300 | 0.001048 | 0.003886 | 0.019123 | 0.113299 | 0.699465 | 4.555086 |
+| **Backward**      | 0.000065 | 0.000289 | 0.000987 | 0.003837 | 0.019529 | 0.114718 | 0.699051 | 4.697958 |
 | **ϵ<sub>2</sub>** | 2.30e-15 | 3.94e-15 | 8.14e-15 | 1.68e-14 | 3.55e-14 | 7.30e-14 | 1.44e-13 | 2.97e-13 |
 | **ϵ<sub>∞</sub>** | 1.09e-14 | 1.84e-14 | 5.49e-14 | 1.49e-13 | 9.06e-13 | 1.95e-12 | 3.73e-12 | 1.05e-11 |
 
@@ -70,8 +70,8 @@ The error growth rate is significantly reduced if (α, β, γ) = (-0.5, -0.5, -0
 
 | Degree            | 63       | 127      | 255      | 511      | 1023     | 2047     | 4095     | 8191     |
 | ----------------: | -------: | -------: | -------: | -------: | -------: | -------: | -------: | -------: |
-| **Forward**       | 0.000275 | 0.001069 | 0.003448 | 0.011251 | 0.053583 | 0.329135 | 2.157533 | 15.33666 |
-| **Backward**      | 0.000280 | 0.001031 | 0.003435 | 0.011320 | 0.053093 | 0.317026 | 2.203625 | 15.42320 |
+| **Forward**       | 0.000209 | 0.001077 | 0.003618 | 0.013243 | 0.064321 | 0.369272 | 2.182001 | 16.15872 |
+| **Backward**      | 0.000208 | 0.001027 | 0.003487 | 0.012903 | 0.064544 | 0.372493 | 2.191747 | 16.43340 |
 | **ϵ<sub>2</sub>** | 7.60e-16 | 9.35e-16 | 1.31e-15 | 1.84e-15 | 2.56e-15 | 3.59e-15 | 5.05e-15 | 7.15e-15 |
 | **ϵ<sub>∞</sub>** | 1.78e-15 | 2.66e-15 | 5.33e-15 | 7.11e-15 | 1.27e-14 | 1.79e-14 | 2.91e-14 | 1.66e-13 |
 

--- a/README.md
+++ b/README.md
@@ -14,20 +14,20 @@ The library makes use of OpenBLAS, FFTW3, and MPFR, which are easily installed v
 
 ### macOS
 
-Apple's version of GCC does not support OpenMP. Sample installation:
+Sample installation:
 ```
-brew install gcc@8 fftw mpfr
-make CC=gcc-8 FT_USE_APPLEBLAS=1
+brew install libomp fftw mpfr
+make CC=clang FT_USE_APPLEBLAS=1
 ```
-On macOS, the OpenBLAS dependency is optional in light of the vecLib framework. In case the library is compiled with vecLib, then the environment variable `VECLIB_MAXIMUM_THREADS` partially controls the multithreading.
+On macOS, the OpenBLAS dependency is optional in light of the vecLib framework, though on macOS 10.14 and above, one must locate the headers in the software development kit. In case the library is compiled with vecLib, then the environment variable `VECLIB_MAXIMUM_THREADS` partially controls the multithreading.
 
 ### Linux
 
 To access functions from the library, you must ensure that you append the current library path to the default. Sample installation:
 ```
-apt-get install gcc-8 libblas-dev libopenblas-base libfftw3-dev libmpfr-dev
+apt-get install libomp-dev libblas-dev libopenblas-base libfftw3-dev libmpfr-dev
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:.
-make CC=gcc-8
+make CC=gcc
 ```
 See the [Travis build](https://github.com/MikaelSlevinsky/FastTransforms/blob/master/.travis.yml) for further details.
 

--- a/src/ftinternal.h
+++ b/src/ftinternal.h
@@ -15,6 +15,9 @@
     #ifndef bit_AVX2
         #define bit_AVX2 0
     #endif
+    #ifndef bit_AVX512F
+        #define bit_AVX512F 0
+    #endif
 #endif
 
 #define RED(string) "\x1b[31m" string "\x1b[0m"
@@ -149,14 +152,10 @@ typedef struct {
         unsigned eax1, ebx1, ecx1, edx1;
         cpuid(1, 0, &eax, &ebx, &ecx, &edx);
         cpuid(7, 0, &eax1, &ebx1, &ecx1, &edx1);
-        #ifndef bit_AVX512F
-            return (ft_simd) {!!(edx & bit_SSE), !!(edx & bit_SSE2), !!(ecx & bit_SSE3), !!(ecx & bit_SSSE3), !!(ecx & bit_SSE4_1), !!(ecx & bit_SSE4_2), !!(ecx & bit_AVX), !!(ebx1 & bit_AVX2), !!(ecx & bit_FMA), 0};
-        #else
-            return (ft_simd) {!!(edx & bit_SSE), !!(edx & bit_SSE2), !!(ecx & bit_SSE3), !!(ecx & bit_SSSE3), !!(ecx & bit_SSE4_1), !!(ecx & bit_SSE4_2), !!(ecx & bit_AVX), !!(ebx1 & bit_AVX2), !!(ecx & bit_FMA), !!(ebx1 & bit_AVX512F)};
-        #endif
+        return (ft_simd) {!!(edx & bit_SSE), !!(edx & bit_SSE2), !!(ecx & bit_SSE3), !!(ecx & bit_SSSE3), !!(ecx & bit_SSE4_1), !!(ecx & bit_SSE4_2), !!(ecx & bit_AVX), !!(ebx1 & bit_AVX2), !!(ecx & bit_FMA), !!(ebx1 & bit_AVX512F)};
     }
 #else
-    static inline ft_simd get_simd(void) {return (ft_simd) {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,};}
+    static inline ft_simd get_simd(void) {return (ft_simd) {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};}
 #endif
 
 #ifdef __AVX512F__

--- a/src/ftutilities.c
+++ b/src/ftutilities.c
@@ -178,10 +178,12 @@ double elapsed(struct timeval * start, struct timeval * end, int N) {
 #undef X
 #undef Y
 
-#define FLT quadruple
-#define X(name) FT_CONCAT(ft_, name, q)
-#define Y(name) FT_CONCAT(, name, q)
-#include "ftutilities_source.c"
-#undef FLT
-#undef X
-#undef Y
+#if defined(FT_QUADMATH)
+    #define FLT quadruple
+    #define X(name) FT_CONCAT(ft_, name, q)
+    #define Y(name) FT_CONCAT(, name, q)
+    #include "ftutilities_source.c"
+    #undef FLT
+    #undef X
+    #undef Y
+#endif

--- a/src/ftutilities.h
+++ b/src/ftutilities.h
@@ -59,12 +59,14 @@ double elapsed(struct timeval * start, struct timeval * end, int N);
 #undef X
 #undef Y
 
-#define FLT quadruple
-#define X(name) FT_CONCAT(ft_, name, q)
-#define Y(name) FT_CONCAT(, name, q)
-#include "ftutilities_source.h"
-#undef FLT
-#undef X
-#undef Y
+#if defined(FT_QUADMATH)
+    #define FLT quadruple
+    #define X(name) FT_CONCAT(ft_, name, q)
+    #define Y(name) FT_CONCAT(, name, q)
+    #include "ftutilities_source.h"
+    #undef FLT
+    #undef X
+    #undef Y
+#endif
 
 #endif //FTUTILITIES_H

--- a/src/hierarchical_source.c
+++ b/src/hierarchical_source.c
@@ -42,7 +42,7 @@ FLT * X(chebyshev_barycentric_weights)(char KIND, int n) {
 // Evaluate a polynomial interpolant of degree n-1 through the distinct points
 // y_j, 0 ≤ j < n at the distinct points x_i, 0 ≤ i < m. This is effected by a
 // matrix-vector product with A_{i,j} and the polynomial interpolant's ordinates.
-void * X(barycentricmatrix)(FLT * A, FLT * x, int m, FLT * y, FLT * l, int n) {
+void X(barycentricmatrix)(FLT * A, FLT * x, int m, FLT * y, FLT * l, int n) {
     int k;
     FLT yj, lj, temp;
     for (int j = 0; j < n; j++) {
@@ -246,10 +246,10 @@ X(hierarchicalmatrix) * X(sample_hierarchicalmatrix)(FLT (*f)(FLT x, FLT y), FLT
     unitrange i1, i2, j1, j2;
     if (SPLITTING == 'I') {
         i1.start = i.start;
-        i1.stop = i2.start = i.start + (i.stop-i.start>>1);
+        i1.stop = i2.start = i.start + ((i.stop-i.start)>>1);
         i2.stop = i.stop;
         j1.start = j.start;
-        j1.stop = j2.start = j.start + (j.stop-j.start>>1);
+        j1.stop = j2.start = j.start + ((j.stop-j.start)>>1);
         j2.stop = j.stop;
     }
     else if (SPLITTING == 'G') {
@@ -325,10 +325,10 @@ X(hierarchicalmatrix) * X(sample_accurately_hierarchicalmatrix)(FLT (*f)(FLT x, 
     unitrange i1, i2, j1, j2;
     if (SPLITTING == 'I') {
         i1.start = i.start;
-        i1.stop = i2.start = i.start + (i.stop-i.start>>1);
+        i1.stop = i2.start = i.start + ((i.stop-i.start)>>1);
         i2.stop = i.stop;
         j1.start = j.start;
-        j1.stop = j2.start = j.start + (j.stop-j.start>>1);
+        j1.stop = j2.start = j.start + ((j.stop-j.start)>>1);
         j2.stop = j.stop;
     }
     else if (SPLITTING == 'G') {
@@ -416,10 +416,10 @@ static inline int X(size_hierarchicalmatrix)(X(hierarchicalmatrix) * H, int k) {
 static inline int X(blocksize_hierarchicalmatrix)(X(hierarchicalmatrix) * H, int m, int n, int k) {
     int M = H->M, N = H->N;
     switch (H->hash(m, n)) {
-        case 0: return 1;
         case 1: return X(size_hierarchicalmatrix)(H->hierarchicalmatrices(m, n), k);
         case 2: return X(size_densematrix)(H->densematrices(m, n), k);
         case 3: return X(size_lowrankmatrix)(H->lowrankmatrices(m, n), k);
+        default: return 1;
     }
 }
 

--- a/src/hierarchical_source.h
+++ b/src/hierarchical_source.h
@@ -49,7 +49,7 @@ struct X(hmat) {
 
 FLT * X(chebyshev_points)(char KIND, int n);
 FLT * X(chebyshev_barycentric_weights)(char KIND, int n);
-void * X(barycentricmatrix)(FLT * A, FLT * x, int m, FLT * y, FLT * l, int n);
+void X(barycentricmatrix)(FLT * A, FLT * x, int m, FLT * y, FLT * l, int n);
 
 void X(destroy_densematrix)(X(densematrix) * A);
 void X(destroy_lowrankmatrix)(X(lowrankmatrix) * A);

--- a/src/rotations/rotations.h
+++ b/src/rotations/rotations.h
@@ -15,7 +15,7 @@
 #define s2(l,j,m) s2[l+(j)*n+(m)*as*n]
 #define c2(l,j,m) c2[l+(j)*n+(m)*as*n]
 
-#define KERNEL_SPH_HI2LO(T, VT, VS, L, VLOAD, VSTORE, APPLY_GIVENS)            \
+#define KERNEL_SPH_HI2LO(T, VT, VS, L, VLOAD, VSTORE, VMULADD, VMULSUB, VALL, APPLY_GIVENS) \
 int n = RP->n, row, col;                                                       \
 T ts, tc;                                                                      \
 VT X[3*L], T1, T2;                                                             \
@@ -37,8 +37,8 @@ for (; j >= m1+2*L-2; j -= 2*L) {                                              \
                 T2 = X[L+1-lk+2*lj];                                           \
                 ts = RP->s(row, col);                                          \
                 tc = RP->c(row, col);                                          \
-                X[L-1-lk+2*lj] = tc*T1 + ts*T2;                                \
-                X[L+1-lk+2*lj] = tc*T2 - ts*T1;                                \
+                X[L-1-lk+2*lj] = VMULADD(VALL(tc), T1, ts*T2);                 \
+                X[L+1-lk+2*lj] = VMULSUB(VALL(tc), T2, ts*T1);                 \
             }                                                                  \
         }                                                                      \
         for (int l = 0; l < 3*L; l++)                                          \
@@ -58,7 +58,7 @@ for (; j >= m1; j -= 2) {                                                      \
     }                                                                          \
 }
 
-#define KERNEL_SPH_LO2HI(T, VT, VS, L, VLOAD, VSTORE, APPLY_GIVENS_T)          \
+#define KERNEL_SPH_LO2HI(T, VT, VS, L, VLOAD, VSTORE, VMULADD, VMULSUB, VALL, APPLY_GIVENS_T) \
 int n = RP->n, row, col;                                                       \
 T ts, tc;                                                                      \
 VT X[3*L], T1, T2;                                                             \
@@ -83,8 +83,8 @@ for (; j < m2-2*L-2*VS+4; j += 2*L) {                                          \
                 T2 = X[2*L+lk-2*lj];                                           \
                 ts = RP->s(row, col);                                          \
                 tc = RP->c(row, col);                                          \
-                X[2*L-2+lk-2*lj] = tc*T1 - ts*T2;                              \
-                X[2*L+lk-2*lj] = tc*T2 + ts*T1;                                \
+                X[2*L-2+lk-2*lj] = VMULSUB(VALL(tc), T1, ts*T2);               \
+                X[2*L+lk-2*lj] = VMULADD(VALL(tc), T2, ts*T1);                 \
             }                                                                  \
         }                                                                      \
         for (int l = 0; l < 3*L; l++)                                          \
@@ -101,7 +101,7 @@ for (int s = 1; s < VS/2; s++) {                                               \
     kernel_sph_lo2hi_default(RP, m2, m2+2*s, A+2*s+1, S);                      \
 }
 
-#define KERNEL_TRI_HI2LO(T, VT, VS, L, VLOAD, VSTORE, APPLY_GIVENS)            \
+#define KERNEL_TRI_HI2LO(T, VT, VS, L, VLOAD, VSTORE, VMULADD, VMULSUB, VALL, APPLY_GIVENS) \
 int n = RP->n, row, col;                                                       \
 T ts, tc;                                                                      \
 VT X[2*L], T1, T2;                                                             \
@@ -121,8 +121,8 @@ for (; j >= m1+L-1; j -= L) {                                                  \
                 T2 = X[L-lk+lj];                                               \
                 ts = RP->s(row, col);                                          \
                 tc = RP->c(row, col);                                          \
-                X[L-1-lk+lj] = tc*T1 + ts*T2;                                  \
-                X[L-lk+lj] = tc*T2 - ts*T1;                                    \
+                X[L-1-lk+lj] = VMULADD(VALL(tc), T1, ts*T2);                   \
+                X[L-lk+lj] = VMULSUB(VALL(tc), T2, ts*T1);                     \
             }                                                                  \
         }                                                                      \
         for (int l = 0; l < 2*L; l++)                                          \
@@ -142,7 +142,7 @@ for (; j >= m1; j--) {                                                         \
     }                                                                          \
 }
 
-#define KERNEL_TRI_LO2HI(T, VT, VS, L, VLOAD, VSTORE, APPLY_GIVENS_T)          \
+#define KERNEL_TRI_LO2HI(T, VT, VS, L, VLOAD, VSTORE, VMULADD, VMULSUB, VALL, APPLY_GIVENS_T) \
 int n = RP->n, row, col;                                                       \
 T ts, tc;                                                                      \
 VT X[2*L], T1, T2;                                                             \
@@ -167,8 +167,8 @@ for (; j < m2-L-VS+2; j += L) {                                                \
                 T2 = X[L+lk-lj];                                               \
                 ts = RP->s(row, col);                                          \
                 tc = RP->c(row, col);                                          \
-                X[L-1+lk-lj] = tc*T1 - ts*T2;                                  \
-                X[L+lk-lj] = tc*T2 + ts*T1;                                    \
+                X[L-1+lk-lj] = VMULSUB(VALL(tc), T1, ts*T2);                   \
+                X[L+lk-lj] = VMULADD(VALL(tc), T2, ts*T1);                     \
             }                                                                  \
         }                                                                      \
         for (int l = 0; l < 2*L; l++)                                          \
@@ -183,7 +183,7 @@ for (; j < m2; j++) {                                                          \
 for (int s = 1; s < VS; s++)                                                   \
     kernel_tri_lo2hi_default(RP, m2, m2+s, A+s, S);
 
-#define KERNEL_DISK_HI2LO(T, VT, VS, L, VLOAD, VSTORE, APPLY_GIVENS)           \
+#define KERNEL_DISK_HI2LO(T, VT, VS, L, VLOAD, VSTORE, VMULADD, VMULSUB, VALL, APPLY_GIVENS) \
 int n = RP->n, row, col;                                                       \
 T ts, tc;                                                                      \
 VT X[2*L], T1, T2;                                                             \
@@ -205,8 +205,8 @@ for (; j >= m1+2*L-1; j -= 2*L) {                                              \
                 T2 = X[L-lk+lj];                                               \
                 ts = RP->sd(row, col);                                         \
                 tc = RP->cd(row, col);                                         \
-                X[L-1-lk+lj] = tc*T1 + ts*T2;                                  \
-                X[L-lk+lj] = tc*T2 - ts*T1;                                    \
+                X[L-1-lk+lj] = VMULADD(VALL(tc), T1, ts*T2);                   \
+                X[L-lk+lj] = VMULSUB(VALL(tc), T2, ts*T1);                     \
             }                                                                  \
         }                                                                      \
         for (int l = 0; l < 2*L; l++)                                          \
@@ -226,7 +226,7 @@ for (; j >= m1; j -= 2) {                                                      \
     }                                                                          \
 }
 
-#define KERNEL_DISK_LO2HI(T, VT, VS, L, VLOAD, VSTORE, APPLY_GIVENS_T)         \
+#define KERNEL_DISK_LO2HI(T, VT, VS, L, VLOAD, VSTORE, VMULADD, VMULSUB, VALL, APPLY_GIVENS_T) \
 int n = RP->n, row, col;                                                       \
 T ts, tc;                                                                      \
 VT X[2*L], T1, T2;                                                             \
@@ -251,8 +251,8 @@ for (; j < m2-2*L-2*VS+4; j += 2*L) {                                          \
                 T2 = X[L+lk-lj];                                               \
                 ts = RP->sd(row, col);                                         \
                 tc = RP->cd(row, col);                                         \
-                X[L-1+lk-lj] = tc*T1 - ts*T2;                                  \
-                X[L+lk-lj] = tc*T2 + ts*T1;                                    \
+                X[L-1+lk-lj] = VMULSUB(VALL(tc), T1, ts*T2);                   \
+                X[L+lk-lj] = VMULADD(VALL(tc), T2, ts*T1);                     \
             }                                                                  \
         }                                                                      \
         for (int l = 0; l < 2*L; l++)                                          \

--- a/src/rotations/rotations_AVX.c
+++ b/src/rotations/rotations_AVX.c
@@ -36,22 +36,22 @@
         vstoreu4(YD, vas4(C*y,  S*x));
     }
     void kernel_sph_hi2lo_AVX(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_SPH_HI2LO(double, double4, 4, 3, vloadu4, vstoreu4, apply_givens_AVX)
+        KERNEL_SPH_HI2LO(double, double4, 4, 3, vloadu4, vstoreu4, vmuladd, vmulsub, vall4, apply_givens_AVX)
     }
     void kernel_sph_lo2hi_AVX(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_SPH_LO2HI(double, double4, 4, 3, vloadu4, vstoreu4, apply_givens_t_AVX)
+        KERNEL_SPH_LO2HI(double, double4, 4, 3, vloadu4, vstoreu4, vmuladd, vmulsub, vall4, apply_givens_t_AVX)
     }
     void kernel_tri_hi2lo_AVX(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_TRI_HI2LO(double, double4, 4, 3, vloadu4, vstoreu4, apply_givens_AVX)
+        KERNEL_TRI_HI2LO(double, double4, 4, 3, vloadu4, vstoreu4, vmuladd, vmulsub, vall4, apply_givens_AVX)
     }
     void kernel_tri_lo2hi_AVX(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_TRI_LO2HI(double, double4, 4, 3, vloadu4, vstoreu4, apply_givens_t_AVX)
+        KERNEL_TRI_LO2HI(double, double4, 4, 3, vloadu4, vstoreu4, vmuladd, vmulsub, vall4, apply_givens_t_AVX)
     }
     void kernel_disk_hi2lo_AVX(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_DISK_HI2LO(double, double4, 4, 3, vloadu4, vstoreu4, apply_givens_AVX)
+        KERNEL_DISK_HI2LO(double, double4, 4, 3, vloadu4, vstoreu4, vmuladd, vmulsub, vall4, apply_givens_AVX)
     }
     void kernel_disk_lo2hi_AVX(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_DISK_LO2HI(double, double4, 4, 3, vloadu4, vstoreu4, apply_givens_t_AVX)
+        KERNEL_DISK_LO2HI(double, double4, 4, 3, vloadu4, vstoreu4, vmuladd, vmulsub, vall4, apply_givens_t_AVX)
     }
     void kernel_spinsph_hi2lo_AVX(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S) {
         int n = SRP->n, s = SRP->s;

--- a/src/rotations/rotations_AVX512F.c
+++ b/src/rotations/rotations_AVX512F.c
@@ -4,32 +4,32 @@
     static inline void apply_givens_AVX512F(const double S, const double C, double * X, double * Y) {
         double8 x = vloadu8(X);
         double8 y = vloadu8(Y);
-        vstoreu8(X, C*x + S*y);
-        vstoreu8(Y, C*y - S*x);
+        vstoreu8(X, vfma8(vall8(C), x, S*y));
+        vstoreu8(Y, vfms8(vall8(C), y, S*x));
     }
     static inline void apply_givens_t_AVX512F(const double S, const double C, double * X, double * Y) {
         double8 x = vloadu8(X);
         double8 y = vloadu8(Y);
-        vstoreu8(X, C*x - S*y);
-        vstoreu8(Y, C*y + S*x);
+        vstoreu8(X, vfms8(vall8(C), x, S*y));
+        vstoreu8(Y, vfma8(vall8(C), y, S*x));
     }
     void kernel_sph_hi2lo_AVX512F(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_SPH_HI2LO(double, double8, 8, 3, vloadu8, vstoreu8, apply_givens_AVX512F)
+        KERNEL_SPH_HI2LO(double, double8, 8, 3, vloadu8, vstoreu8, vfma8, vfms8, vall8, apply_givens_AVX512F)
     }
     void kernel_sph_lo2hi_AVX512F(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_SPH_LO2HI(double, double8, 8, 3, vloadu8, vstoreu8, apply_givens_t_AVX512F)
+        KERNEL_SPH_LO2HI(double, double8, 8, 3, vloadu8, vstoreu8, vfma8, vfms8, vall8, apply_givens_t_AVX512F)
     }
     void kernel_tri_hi2lo_AVX512F(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_TRI_HI2LO(double, double8, 8, 3, vloadu8, vstoreu8, apply_givens_AVX512F)
+        KERNEL_TRI_HI2LO(double, double8, 8, 3, vloadu8, vstoreu8, vfma8, vfms8, vall8, apply_givens_AVX512F)
     }
     void kernel_tri_lo2hi_AVX512F(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_TRI_LO2HI(double, double8, 8, 3, vloadu8, vstoreu8, apply_givens_t_AVX512F)
+        KERNEL_TRI_LO2HI(double, double8, 8, 3, vloadu8, vstoreu8, vfma8, vfms8, vall8, apply_givens_t_AVX512F)
     }
     void kernel_disk_hi2lo_AVX512F(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_DISK_HI2LO(double, double8, 8, 3, vloadu8, vstoreu8, apply_givens_AVX512F)
+        KERNEL_DISK_HI2LO(double, double8, 8, 3, vloadu8, vstoreu8, vfma8, vfms8, vall8, apply_givens_AVX512F)
     }
     void kernel_disk_lo2hi_AVX512F(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_DISK_LO2HI(double, double8, 8, 3, vloadu8, vstoreu8, apply_givens_t_AVX512F)
+        KERNEL_DISK_LO2HI(double, double8, 8, 3, vloadu8, vstoreu8, vfma8, vfms8, vall8, apply_givens_t_AVX512F)
     }
 #else
     void kernel_sph_hi2lo_AVX512F(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {

--- a/src/rotations/rotations_AVX_FMA.c
+++ b/src/rotations/rotations_AVX_FMA.c
@@ -5,14 +5,14 @@
         static inline void apply_givens_AVX_FMA(const double S, const double C, double * X, double * Y) {
             double4 x = vloadu4(X);
             double4 y = vloadu4(Y);
-            vstoreu4(X, C*x + S*y);
-            vstoreu4(Y, C*y - S*x);
+            vstoreu4(X, vfma4(vall4(C), x, S*y));
+            vstoreu4(Y, vfms4(vall4(C), y, S*x));
         }
         static inline void apply_givens_t_AVX_FMA(const double S, const double C, double * X, double * Y) {
             double4 x = vloadu4(X);
             double4 y = vloadu4(Y);
-            vstoreu4(X, C*x - S*y);
-            vstoreu4(Y, C*y + S*x);
+            vstoreu4(X, vfms4(vall4(C), x, S*y));
+            vstoreu4(Y, vfma4(vall4(C), y, S*x));
         }
         static inline void apply_givens_AVX_FMAc(const double S, const double C, ft_complex * X, ft_complex * Y) {
             apply_givens_AVX_FMA(S, C, (double *) X, (double *) Y);
@@ -37,22 +37,22 @@
             vstoreu4(YD, vfmas4(vall4(C), y,  S*x));
         }
         void kernel_sph_hi2lo_AVX_FMA(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-            KERNEL_SPH_HI2LO(double, double4, 4, 3, vloadu4, vstoreu4, apply_givens_AVX_FMA)
+            KERNEL_SPH_HI2LO(double, double4, 4, 3, vloadu4, vstoreu4, vfma4, vfms4, vall4, apply_givens_AVX_FMA)
         }
         void kernel_sph_lo2hi_AVX_FMA(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-            KERNEL_SPH_LO2HI(double, double4, 4, 3, vloadu4, vstoreu4, apply_givens_t_AVX_FMA)
+            KERNEL_SPH_LO2HI(double, double4, 4, 3, vloadu4, vstoreu4, vfma4, vfms4, vall4, apply_givens_t_AVX_FMA)
         }
         void kernel_tri_hi2lo_AVX_FMA(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-            KERNEL_TRI_HI2LO(double, double4, 4, 3, vloadu4, vstoreu4, apply_givens_AVX_FMA)
+            KERNEL_TRI_HI2LO(double, double4, 4, 3, vloadu4, vstoreu4, vfma4, vfms4, vall4, apply_givens_AVX_FMA)
         }
         void kernel_tri_lo2hi_AVX_FMA(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-            KERNEL_TRI_LO2HI(double, double4, 4, 3, vloadu4, vstoreu4, apply_givens_t_AVX_FMA)
+            KERNEL_TRI_LO2HI(double, double4, 4, 3, vloadu4, vstoreu4, vfma4, vfms4, vall4, apply_givens_t_AVX_FMA)
         }
         void kernel_disk_hi2lo_AVX_FMA(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-            KERNEL_DISK_HI2LO(double, double4, 4, 3, vloadu4, vstoreu4, apply_givens_AVX_FMA)
+            KERNEL_DISK_HI2LO(double, double4, 4, 3, vloadu4, vstoreu4, vfma4, vfms4, vall4, apply_givens_AVX_FMA)
         }
         void kernel_disk_lo2hi_AVX_FMA(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-            KERNEL_DISK_LO2HI(double, double4, 4, 3, vloadu4, vstoreu4, apply_givens_t_AVX_FMA)
+            KERNEL_DISK_LO2HI(double, double4, 4, 3, vloadu4, vstoreu4, vfma4, vfms4, vall4, apply_givens_t_AVX_FMA)
         }
         void kernel_spinsph_hi2lo_AVX_FMA(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S) {
             int n = SRP->n, s = SRP->s;

--- a/src/rotations/rotations_SSE2.c
+++ b/src/rotations/rotations_SSE2.c
@@ -20,22 +20,22 @@
         apply_givens_t_SSE2(S, C, (double *) X, (double *) Y);
     }
     void kernel_sph_hi2lo_SSE2(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_SPH_HI2LO(double, double2, 2, 3, vloadu2, vstoreu2, apply_givens_SSE2)
+        KERNEL_SPH_HI2LO(double, double2, 2, 3, vloadu2, vstoreu2, vmuladd, vmulsub, vall2, apply_givens_SSE2)
     }
     void kernel_sph_lo2hi_SSE2(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_SPH_LO2HI(double, double2, 2, 3, vloadu2, vstoreu2, apply_givens_t_SSE2)
+        KERNEL_SPH_LO2HI(double, double2, 2, 3, vloadu2, vstoreu2, vmuladd, vmulsub, vall2, apply_givens_t_SSE2)
     }
     void kernel_tri_hi2lo_SSE2(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_TRI_HI2LO(double, double2, 2, 3, vloadu2, vstoreu2, apply_givens_SSE2)
+        KERNEL_TRI_HI2LO(double, double2, 2, 3, vloadu2, vstoreu2, vmuladd, vmulsub, vall2, apply_givens_SSE2)
     }
     void kernel_tri_lo2hi_SSE2(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_TRI_LO2HI(double, double2, 2, 3, vloadu2, vstoreu2, apply_givens_t_SSE2)
+        KERNEL_TRI_LO2HI(double, double2, 2, 3, vloadu2, vstoreu2, vmuladd, vmulsub, vall2, apply_givens_t_SSE2)
     }
     void kernel_disk_hi2lo_SSE2(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_DISK_HI2LO(double, double2, 2, 3, vloadu2, vstoreu2, apply_givens_SSE2)
+        KERNEL_DISK_HI2LO(double, double2, 2, 3, vloadu2, vstoreu2, vmuladd, vmulsub, vall2, apply_givens_SSE2)
     }
     void kernel_disk_lo2hi_SSE2(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_DISK_LO2HI(double, double2, 2, 3, vloadu2, vstoreu2, apply_givens_t_SSE2)
+        KERNEL_DISK_LO2HI(double, double2, 2, 3, vloadu2, vstoreu2, vmuladd, vmulsub, vall2, apply_givens_t_SSE2)
     }
     void kernel_spinsph_hi2lo_SSE2(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S) {
         int n = SRP->n, s = SRP->s;

--- a/src/tdc.c
+++ b/src/tdc.c
@@ -4,40 +4,61 @@
 #define TB_EIGEN_BLOCKSIZE 128
 #define TDC_EIGEN_BLOCKSIZE 128
 
-#define FLT quadruple
-#define X(name) FT_CONCAT(ft_, name, q)
-#define Y(name) FT_CONCAT(, name, q)
-#define BLOCKRANK 2*((int) floor(-log(Y(eps)())/2.271667761226165))
-#define BLOCKSIZE 4*BLOCKRANK
-#include "tridiagonal_source.c"
-#include "hierarchical_source.c"
-#include "banded_source.c"
-#include "dprk_source.c"
-#include "tdc_source.c"
-#undef FLT
-#undef X
-#undef Y
-#undef BLOCKRANK
-#undef BLOCKSIZE
+#if defined(FT_QUADMATH)
+    #define FLT quadruple
+    #define X(name) FT_CONCAT(ft_, name, q)
+    #define Y(name) FT_CONCAT(, name, q)
+    #define BLOCKRANK 2*((int) floor(-log(Y(eps)())/2.271667761226165))
+    #define BLOCKSIZE 4*BLOCKRANK
+    #include "tridiagonal_source.c"
+    #include "hierarchical_source.c"
+    #include "banded_source.c"
+    #include "dprk_source.c"
+    #include "tdc_source.c"
+    #undef FLT
+    #undef X
+    #undef Y
+    #undef BLOCKRANK
+    #undef BLOCKSIZE
 
-#define FLT long double
-#define X(name) FT_CONCAT(ft_, name, l)
-#define X2(name) FT_CONCAT(ft_, name, q)
-#define Y(name) FT_CONCAT(, name, l)
-#define BLOCKRANK 2*((int) floor(-log(Y(eps)())/2.271667761226165))
-#define BLOCKSIZE 4*BLOCKRANK
-#include "tridiagonal_source.c"
-#include "hierarchical_source.c"
-#include "banded_source.c"
-#include "dprk_source.c"
-#include "tdc_source.c"
-#include "drop_precision.c"
-#undef FLT
-#undef X
-#undef X2
-#undef Y
-#undef BLOCKRANK
-#undef BLOCKSIZE
+    #define FLT long double
+    #define X(name) FT_CONCAT(ft_, name, l)
+    #define X2(name) FT_CONCAT(ft_, name, q)
+    #define Y(name) FT_CONCAT(, name, l)
+    #define BLOCKRANK 2*((int) floor(-log(Y(eps)())/2.271667761226165))
+    #define BLOCKSIZE 4*BLOCKRANK
+    #include "tridiagonal_source.c"
+    #include "hierarchical_source.c"
+    #include "banded_source.c"
+    #include "dprk_source.c"
+    #include "tdc_source.c"
+    #include "drop_precision.c"
+    #undef FLT
+    #undef X
+    #undef X2
+    #undef Y
+    #undef BLOCKRANK
+    #undef BLOCKSIZE
+#else
+    #define FLT long double
+    #define X(name) FT_CONCAT(ft_, name, l)
+    #define X2(name) FT_CONCAT(ft_, name, l)
+    #define Y(name) FT_CONCAT(, name, l)
+    #define BLOCKRANK 2*((int) floor(-log(Y(eps)())/2.271667761226165))
+    #define BLOCKSIZE 4*BLOCKRANK
+    #include "tridiagonal_source.c"
+    #include "hierarchical_source.c"
+    #include "banded_source.c"
+    #include "dprk_source.c"
+    #include "tdc_source.c"
+    #include "drop_precision.c"
+    #undef FLT
+    #undef X
+    #undef X2
+    #undef Y
+    #undef BLOCKRANK
+    #undef BLOCKSIZE
+#endif
 
 #define FLT double
 #define X(name) FT_CONCAT(ft_, name, )

--- a/src/tdc.h
+++ b/src/tdc.h
@@ -16,32 +16,49 @@ typedef struct {
 #define densematrices(m,n) densematrices[(m)+(n)*M]
 #define lowrankmatrices(m,n) lowrankmatrices[(m)+(n)*M]
 
-#define FLT __float128
-#define X(name) FT_CONCAT(ft_, name, q)
-#define Y(name) FT_CONCAT(, name, q)
-#include "tridiagonal_source.h"
-#include "hierarchical_source.h"
-#include "banded_source.h"
-#include "dprk_source.h"
-#include "tdc_source.h"
-#undef FLT
-#undef X
-#undef Y
+#if defined(FT_QUADMATH)
+    #define FLT __float128
+    #define X(name) FT_CONCAT(ft_, name, q)
+    #define Y(name) FT_CONCAT(, name, q)
+    #include "tridiagonal_source.h"
+    #include "hierarchical_source.h"
+    #include "banded_source.h"
+    #include "dprk_source.h"
+    #include "tdc_source.h"
+    #undef FLT
+    #undef X
+    #undef Y
 
-#define FLT long double
-#define X(name) FT_CONCAT(ft_, name, l)
-#define X2(name) FT_CONCAT(ft_, name, q)
-#define Y(name) FT_CONCAT(, name, l)
-#include "tridiagonal_source.h"
-#include "hierarchical_source.h"
-#include "banded_source.h"
-#include "dprk_source.h"
-#include "tdc_source.h"
-#include "drop_precision.h"
-#undef FLT
-#undef X
-#undef X2
-#undef Y
+    #define FLT long double
+    #define X(name) FT_CONCAT(ft_, name, l)
+    #define X2(name) FT_CONCAT(ft_, name, q)
+    #define Y(name) FT_CONCAT(, name, l)
+    #include "tridiagonal_source.h"
+    #include "hierarchical_source.h"
+    #include "banded_source.h"
+    #include "dprk_source.h"
+    #include "tdc_source.h"
+    #include "drop_precision.h"
+    #undef FLT
+    #undef X
+    #undef X2
+    #undef Y
+#else
+    #define FLT long double
+    #define X(name) FT_CONCAT(ft_, name, l)
+    #define X2(name) FT_CONCAT(ft_, name, l)
+    #define Y(name) FT_CONCAT(, name, l)
+    #include "tridiagonal_source.h"
+    #include "hierarchical_source.h"
+    #include "banded_source.h"
+    #include "dprk_source.h"
+    #include "tdc_source.h"
+    #include "drop_precision.h"
+    #undef FLT
+    #undef X
+    #undef X2
+    #undef Y
+#endif
 
 #define FLT double
 #define X(name) FT_CONCAT(ft_, name, )

--- a/src/transforms.c
+++ b/src/transforms.c
@@ -3,17 +3,19 @@
 #include "fasttransforms.h"
 #include "ftinternal.h"
 
-#define FLT long double
-#define FLT2 quadruple
-#define X(name) FT_CONCAT(ft_, name, l)
-#define X2(name) FT_CONCAT(ft_, name, q)
-#define Y2(name) FT_CONCAT(, name, q)
-#include "transforms_source.c"
-#undef FLT
-#undef FLT2
-#undef X
-#undef X2
-#undef Y2
+#if defined(FT_QUADMATH)
+    #define FLT long double
+    #define FLT2 quadruple
+    #define X(name) FT_CONCAT(ft_, name, l)
+    #define X2(name) FT_CONCAT(ft_, name, q)
+    #define Y2(name) FT_CONCAT(, name, q)
+    #include "transforms_source.c"
+    #undef FLT
+    #undef FLT2
+    #undef X
+    #undef X2
+    #undef Y2
+#endif
 
 #define FLT double
 #define FLT2 long double

--- a/src/transforms_source.c
+++ b/src/transforms_source.c
@@ -299,7 +299,7 @@ X(tb_eigen_FMM) * X(plan_jacobi_to_chebyshev)(const int normjac, const int normc
     if (normcheb == 0) {
         FLT * sclrow = malloc(n*sizeof(FLT));
         FLT sqrt_1_pi = 1/Y2(tgamma)(0.5);
-        FLT sqrt_2_pi = Y2(sqrt)(2)*sqrt_1_pi;
+        FLT sqrt_2_pi = Y2(sqrt)(2)/Y2(tgamma)(0.5);
         if (n > 0)
             sclrow[0] = sqrt_1_pi;
         for (int i = 1; i < n; i++)
@@ -331,7 +331,7 @@ X(tb_eigen_FMM) * X(plan_ultraspherical_to_chebyshev)(const int normultra, const
     if (normcheb == 0) {
         FLT * sclrow = malloc(n*sizeof(FLT));
         FLT sqrt_1_pi = 1/Y2(tgamma)(0.5);
-        FLT sqrt_2_pi = Y2(sqrt)(2)*sqrt_1_pi;
+        FLT sqrt_2_pi = Y2(sqrt)(2)/Y2(tgamma)(0.5);
         if (n > 0)
             sclrow[0] = sqrt_1_pi;
         for (int i = 1; i < n; i++)

--- a/test/test_banded.c
+++ b/test/test_banded.c
@@ -25,13 +25,15 @@
 #undef X
 #undef Y
 
-#define FLT quadruple
-#define X(name) FT_CONCAT(ft_, name, q)
-#define Y(name) FT_CONCAT(, name, q)
-#include "test_banded_source.c"
-#undef FLT
-#undef X
-#undef Y
+#if defined(FT_QUADMATH)
+    #define FLT quadruple
+    #define X(name) FT_CONCAT(ft_, name, q)
+    #define Y(name) FT_CONCAT(, name, q)
+    #include "test_banded_source.c"
+    #undef FLT
+    #undef X
+    #undef Y
+#endif
 
 int main(void) {
     int checksum = 0;
@@ -42,8 +44,10 @@ int main(void) {
     test_banded(&checksum);
     printf("\n\tLong double precision.\n\n");
     test_bandedl(&checksum);
-    printf("\n\tQuadruple precision.\n\n");
-    test_bandedq(&checksum);
+    #if defined(FT_QUADMATH)
+        printf("\n\tQuadruple precision.\n\n");
+        test_bandedq(&checksum);
+    #endif
     printf("\n");
     return checksum;
 }

--- a/test/test_dprk.c
+++ b/test/test_dprk.c
@@ -25,13 +25,15 @@
 #undef X
 #undef Y
 
-#define FLT quadruple
-#define X(name) FT_CONCAT(ft_, name, q)
-#define Y(name) FT_CONCAT(, name, q)
-#include "test_dprk_source.c"
-#undef FLT
-#undef X
-#undef Y
+#if defined(FT_QUADMATH)
+    #define FLT quadruple
+    #define X(name) FT_CONCAT(ft_, name, q)
+    #define Y(name) FT_CONCAT(, name, q)
+    #include "test_dprk_source.c"
+    #undef FLT
+    #undef X
+    #undef Y
+#endif
 
 int main(void) {
     int checksum = 0;
@@ -42,8 +44,10 @@ int main(void) {
     test_dprk(&checksum);
     printf("\n\tLong double precision.\n\n");
     test_dprkl(&checksum);
-    printf("\n\tQuadruple precision.\n\n");
-    test_dprkq(&checksum);
+    #if defined(FT_QUADMATH)
+        printf("\n\tQuadruple precision.\n\n");
+        test_dprkq(&checksum);
+    #endif
     printf("\n");
     return checksum;
 }

--- a/test/test_drivers.c
+++ b/test/test_drivers.c
@@ -344,7 +344,6 @@ int main(int argc, const char * argv[]) {
         free(B);
         ft_destroy_rotation_plan(RP);
     }
-    printf("];\n");
 
     printf("\nTiming spherical vector field drivers.\n\n");
     printf("t3 = [\n");

--- a/test/test_hierarchical.c
+++ b/test/test_hierarchical.c
@@ -25,13 +25,15 @@
 #undef X
 #undef Y
 
-#define FLT quadruple
-#define X(name) FT_CONCAT(ft_, name, q)
-#define Y(name) FT_CONCAT(, name, q)
-#include "test_hierarchical_source.c"
-#undef FLT
-#undef X
-#undef Y
+#if defined(FT_QUADMATH)
+    #define FLT quadruple
+    #define X(name) FT_CONCAT(ft_, name, q)
+    #define Y(name) FT_CONCAT(, name, q)
+    #include "test_hierarchical_source.c"
+    #undef FLT
+    #undef X
+    #undef Y
+#endif
 
 int main(void) {
     int checksum = 0;
@@ -42,8 +44,10 @@ int main(void) {
     test_hierarchical(&checksum);
     printf("\n\tLong double precision.\n\n");
     test_hierarchicall(&checksum);
-    printf("\n\tQuadruple precision.\n\n");
-    test_hierarchicalq(&checksum);
+    #if defined(FT_QUADMATH)
+        printf("\n\tQuadruple precision.\n\n");
+        test_hierarchicalq(&checksum);
+    #endif
     printf("\n");
     return checksum;
 }

--- a/test/test_rotations.c
+++ b/test/test_rotations.c
@@ -517,6 +517,7 @@ int main(void) {
             ft_destroy_spin_rotation_plan(SRP);
         }
     }
+    printf("\n");
     return checksum;
 }
 

--- a/test/test_tdc.c
+++ b/test/test_tdc.c
@@ -1,13 +1,15 @@
 #include "fasttransforms.h"
 #include "ftutilities.h"
 
-#define FLT quadruple
-#define X(name) FT_CONCAT(ft_, name, q)
-#define Y(name) FT_CONCAT(, name, q)
-#include "test_tdc_source.c"
-#undef FLT
-#undef X
-#undef Y
+#if defined(FT_QUADMATH)
+    #define FLT quadruple
+    #define X(name) FT_CONCAT(ft_, name, q)
+    #define Y(name) FT_CONCAT(, name, q)
+    #include "test_tdc_source.c"
+    #undef FLT
+    #undef X
+    #undef Y
+#endif
 
 #define FLT long double
 #define X(name) FT_CONCAT(ft_, name, l)
@@ -48,8 +50,10 @@ int main(void) {
     test_tdc(&checksum);
     printf("\n\tLong double precision.\n\n");
     test_tdcl(&checksum);
-    printf("\n\tQuadruple precision.\n\n");
-    test_tdcq(&checksum);
+    #if defined(FT_QUADMATH)
+        printf("\n\tQuadruple precision.\n\n");
+        test_tdcq(&checksum);
+    #endif
     printf("\n");
     printf("\nTesting methods for dropping the precision.\n");
     printf("\n\tDouble ↘  single precision.\n\n");

--- a/test/test_transforms.c
+++ b/test/test_transforms.c
@@ -17,13 +17,15 @@
 #undef X
 #undef Y
 
-#define FLT long double
-#define X(name) FT_CONCAT(ft_, name, l)
-#define Y(name) FT_CONCAT(, name, l)
-#include "test_transforms_source.c"
-#undef FLT
-#undef X
-#undef Y
+#if defined(FT_QUADMATH)
+    #define FLT long double
+    #define X(name) FT_CONCAT(ft_, name, l)
+    #define Y(name) FT_CONCAT(, name, l)
+    #include "test_transforms_source.c"
+    #undef FLT
+    #undef X
+    #undef Y
+#endif
 
 #include "test_transforms_mpfr.c"
 

--- a/test/test_transforms_mpfr.c
+++ b/test/test_transforms_mpfr.c
@@ -130,7 +130,7 @@ void test_transforms_mpfr(int * checksum, int N, mpfr_prec_t prec, mpfr_rnd_t rn
                 }
             }
             printf("(n×n) = (%4ix%4i), (%+1.2f) → (%+1.2f): \t\t |%20.2e ", n, n, mpfr_get_d(lambda, rnd), mpfr_get_d(mu, rnd), mpfr_get_d(err, rnd));
-            ft_mpfr_checktest(&err, 4*pow(n, 2*fabs(mu-lambda)), checksum, prec, rnd);
+            ft_mpfr_checktest(&err, 4*pow(n, 0.5+fabs(mpfr_get_d(mu, rnd)-mpfr_get_d(lambda, rnd))), checksum, prec, rnd);
             ft_mpfr_destroy_plan(B, n);
         }
         ft_mpfr_destroy_plan(Id, n);
@@ -215,7 +215,7 @@ void test_transforms_mpfr(int * checksum, int N, mpfr_prec_t prec, mpfr_rnd_t rn
                 }
             }
             printf("(n×n) = (%4ix%4i), (%+1.2f, %+1.2f) → (%+1.2f, %+1.2f): \t |%20.2e ", n, n, mpfr_get_d(alpha, rnd), mpfr_get_d(beta, rnd), mpfr_get_d(gamma, rnd), mpfr_get_d(delta, rnd), mpfr_get_d(err, rnd));
-            ft_mpfr_checktest(&err, 32*pow(n, 2*(MAX(fabs(gamma-alpha), fabs(delta-beta)))), checksum, prec, rnd);
+            ft_mpfr_checktest(&err, 32*pow(n, 0.5+MAX(fabs(mpfr_get_d(gamma, rnd)-mpfr_get_d(alpha, rnd)), fabs(mpfr_get_d(delta, rnd)-mpfr_get_d(beta, rnd)))), checksum, prec, rnd);
             ft_mpfr_destroy_plan(B, n);
         }
         ft_mpfr_destroy_plan(Id, n);
@@ -262,7 +262,7 @@ void test_transforms_mpfr(int * checksum, int N, mpfr_prec_t prec, mpfr_rnd_t rn
                 }
             }
             printf("(n×n) = (%4ix%4i), (%+1.2f) → (%+1.2f): \t\t |%20.2e ", n, n, mpfr_get_d(alpha, rnd), mpfr_get_d(beta, rnd), mpfr_get_d(err, rnd));
-            ft_mpfr_checktest(&err, 4*pow(n, 2*fabs(alpha-beta)), checksum, prec, rnd);
+            ft_mpfr_checktest(&err, 4*pow(n, 2*fabs(mpfr_get_d(alpha, rnd)-mpfr_get_d(beta, rnd))), checksum, prec, rnd);
             ft_mpfr_destroy_plan(B, n);
         }
         ft_mpfr_destroy_plan(Id, n);

--- a/test/test_tridiagonal.c
+++ b/test/test_tridiagonal.c
@@ -25,13 +25,15 @@
 #undef X
 #undef Y
 
-#define FLT quadruple
-#define X(name) FT_CONCAT(ft_, name, q)
-#define Y(name) FT_CONCAT(, name, q)
-#include "test_tridiagonal_source.c"
-#undef FLT
-#undef X
-#undef Y
+#if defined(FT_QUADMATH)
+    #define FLT quadruple
+    #define X(name) FT_CONCAT(ft_, name, q)
+    #define Y(name) FT_CONCAT(, name, q)
+    #include "test_tridiagonal_source.c"
+    #undef FLT
+    #undef X
+    #undef Y
+#endif
 
 void symmetric_tridiagonal_printmat(char * MAT, char * FMT, ft_symmetric_tridiagonal * A);
 void bidiagonal_printmat(char * MAT, char * FMT, ft_bidiagonal * B);
@@ -45,8 +47,10 @@ int main(void) {
     test_tridiagonal(&checksum);
     printf("\n\tLong double precision.\n\n");
     test_tridiagonall(&checksum);
-    printf("\n\tQuadruple precision.\n\n");
-    test_tridiagonalq(&checksum);
+    #if defined(FT_QUADMATH)
+        printf("\n\tQuadruple precision.\n\n");
+        test_tridiagonalq(&checksum);
+    #endif
     printf("\n");
     return checksum;
 }


### PR DESCRIPTION
Allow code to be compiled by clang, make quadmath optional, sequester x86-specific code, fix miscellaneous warnings generated by clang.