### PR TITLE
Support AArch64 linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
         apt:
           sources: ubuntu-toolchain-r-test
           packages: ['libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+      env: JOBS_EVAL="export CC=gcc && export COV=gcov && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
       after_success:
         - make coverage
         - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
         apt:
           sources: ubuntu-toolchain-r-test
           packages: ['libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc && export FT_QUADMATH=1 && export COV=gcov && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+      env: JOBS_EVAL="export CC=gcc && export FT_QUADMATH=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
       after_success:
         - make coverage
         - bash <(curl -s https://codecov.io/bash)
@@ -52,7 +52,7 @@ jobs:
         apt:
           sources: ubuntu-toolchain-r-test
           packages: ['libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc && export COV=gcov && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+      env: JOBS_EVAL="export CC=gcc && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
       after_success:
         - make coverage
         - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,25 @@ jobs:
           packages: ['libomp', 'openblas', 'fftw', 'mpfr']
       env: JOBS_EVAL="export CC=gcc"
     - os: linux
+      arch: amd64
+      compiler: clang
+      addons:
+        apt:
+          sources: ubuntu-toolchain-r-test
+          packages: ['libomp-dev', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
+      env: JOBS_EVAL="export CC=clang && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+    - os: linux
+      arch: amd64
+      compiler: gcc
+      addons:
+        apt:
+          sources: ubuntu-toolchain-r-test
+          packages: ['libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
+      env: JOBS_EVAL="export CC=gcc && export FT_QUADMATH=1 && export COV=gcov && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+      after_success:
+        - make coverage
+        - bash <(curl -s https://codecov.io/bash)
+    - os: linux
       arch: arm64
       compiler: clang
       addons:
@@ -33,7 +52,7 @@ jobs:
         apt:
           sources: ubuntu-toolchain-r-test
           packages: ['libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc && export COV=gcov && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+      env: JOBS_EVAL="export CC=gcc && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
       after_success:
         - make coverage
         - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
         apt:
           sources: ubuntu-toolchain-r-test
           packages: ['libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc && export FT_QUADMATH=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+      env: JOBS_EVAL="export CC=gcc && export FT_QUADMATH=1 && export COV=gcov && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
       after_success:
         - make coverage
         - bash <(curl -s https://codecov.io/bash)
@@ -52,7 +52,7 @@ jobs:
         apt:
           sources: ubuntu-toolchain-r-test
           packages: ['libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+      env: JOBS_EVAL="export CC=gcc && export COV=gcov && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
       after_success:
         - make coverage
         - bash <(curl -s https://codecov.io/bash)
@@ -76,7 +76,7 @@ before_install: eval "${JOBS_EVAL}"
 
 script:
   - make
-  - make runtests FT_NUM_THREADS=1
+  - make runtests FT_NUM_THREADS=4
   - make runexamples
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ before_install: eval "${JOBS_EVAL}"
 
 script:
   - make
-  - make runtests FT_NUM_THREADS=4
+  - make runtests FT_NUM_THREADS=1
   - make runexamples
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,25 +19,6 @@ jobs:
           packages: ['libomp', 'openblas', 'fftw', 'mpfr']
       env: JOBS_EVAL="export CC=gcc"
     - os: linux
-      arch: amd64
-      compiler: clang
-      addons:
-        apt:
-          sources: ubuntu-toolchain-r-test
-          packages: ['libomp-dev', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=clang && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
-    - os: linux
-      arch: amd64
-      compiler: gcc
-      addons:
-        apt:
-          sources: ubuntu-toolchain-r-test
-          packages: ['libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc && export FT_QUADMATH=1 && export COV=gcov && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
-      after_success:
-        - make coverage
-        - bash <(curl -s https://codecov.io/bash)
-    - os: linux
       arch: arm64
       compiler: clang
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,26 @@ jobs:
           packages: ['libomp', 'openblas', 'fftw', 'mpfr']
       env: JOBS_EVAL="export CC=gcc"
     - os: linux
+      arch: amd64
+      compiler: clang
+      addons:
+        apt:
+          sources: ubuntu-toolchain-r-test
+          packages: ['libomp-dev', 'libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
+      env: JOBS_EVAL="export CC=clang && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+    - os: linux
+      arch: amd64
+      compiler: gcc
+      addons:
+        apt:
+          sources: ubuntu-toolchain-r-test
+          packages: ['libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
+      env: JOBS_EVAL="export CC=gcc && export FT_QUADMATH=1 && export COV=gcov && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+      after_success:
+        - make coverage
+        - bash <(curl -s https://codecov.io/bash)
+    - os: linux
+      arch: arm64
       compiler: clang
       addons:
         apt:
@@ -27,6 +47,7 @@ jobs:
       env: JOBS_EVAL="export CC=clang && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
     - os: linux
       compiler: gcc
+      arch: arm64
       addons:
         apt:
           sources: ubuntu-toolchain-r-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
         apt:
           sources: ubuntu-toolchain-r-test
           packages: ['libblas-dev', 'libopenblas-base', 'libfftw3-dev', 'libmpfr-dev']
-      env: JOBS_EVAL="export CC=gcc && export FT_QUADMATH=1 && export COV=gcov && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
+      env: JOBS_EVAL="export CC=gcc && export COV=gcov && export FT_COVERAGE=1 && export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:."
       after_success:
         - make coverage
         - bash <(curl -s https://codecov.io/bash)

--- a/Make.inc
+++ b/Make.inc
@@ -55,8 +55,8 @@ ifneq (, $(filter -mavx512f +avx512f, $(simd)))
         MAVX512F := -mavx512f
     endif
 endif
-ifneq (, $(filter armv8-a, $(simd)))
-    MNEON := -mfpu=neon
+ifneq (, $(filter -march=armv8-a%, $(simd)))
+    MNEON := -mfpu=neon -funsafe-math-optimizations
 endif
 
 ifeq ($(UNAME), Darwin)

--- a/Make.inc
+++ b/Make.inc
@@ -55,9 +55,6 @@ ifneq (, $(filter -mavx512f +avx512f, $(simd)))
         MAVX512F := -mavx512f
     endif
 endif
-ifneq (, $(filter -march=armv8-a%, $(simd)))
-    MNEON := -march=armv8-a+simd
-endif
 
 ifeq ($(UNAME), Darwin)
     SLIB = dylib

--- a/Make.inc
+++ b/Make.inc
@@ -55,6 +55,9 @@ ifneq (, $(filter -mavx512f +avx512f, $(simd)))
         MAVX512F := -mavx512f
     endif
 endif
+ifneq (, $(filter armv8-a, $(simd)))
+    MNEON := -mfpu=neon
+endif
 
 ifeq ($(UNAME), Darwin)
     SLIB = dylib
@@ -70,6 +73,7 @@ ASM = src/recurrence/recurrence_default.s \
       src/recurrence/recurrence_AVX.s \
       src/recurrence/recurrence_AVX_FMA.s \
       src/recurrence/recurrence_AVX512F.s \
+      src/recurrence/recurrence_NEON.s \
       src/permute/permute_default.s \
       src/permute/permute_SSE.s \
       src/permute/permute_SSE2.s \
@@ -88,10 +92,7 @@ machine := $(shell $(CC) -dumpmachine | cut -d'-' -f1)
 AFLAGS += -O3 -fPIC -std=gnu11 -I./src
 
 ifndef CFLAGS
-    CFLAGS = -O3
-    ifneq (, $(findstring 86, $(machine)))
-        CFLAGS += -march=native
-    endif
+    CFLAGS = -O3 -march=native
 endif
 CFLAGS += -std=gnu11 -I./src
 

--- a/Make.inc
+++ b/Make.inc
@@ -97,7 +97,9 @@ ifndef CFLAGS
         CFLAGS += -march=native
     endif
     ifneq (, $(findstring aarch64, $(machine)))
-        CFLAGS += -mcpu=native
+        ifeq (, $(findstring clang, $(shell $(CC) --version)))
+            CFLAGS += -mcpu=native
+        endif
     endif
 endif
 CFLAGS += -std=gnu11 -I./src

--- a/Make.inc
+++ b/Make.inc
@@ -56,7 +56,7 @@ ifneq (, $(filter -mavx512f +avx512f, $(simd)))
     endif
 endif
 ifneq (, $(filter -march=armv8-a%, $(simd)))
-    MNEON := -mfpu=neon -funsafe-math-optimizations
+    MNEON := -march=armv8-a+simd
 endif
 
 ifeq ($(UNAME), Darwin)

--- a/Make.inc
+++ b/Make.inc
@@ -92,7 +92,13 @@ machine := $(shell $(CC) -dumpmachine | cut -d'-' -f1)
 AFLAGS += -O3 -fPIC -std=gnu11 -I./src
 
 ifndef CFLAGS
-    CFLAGS = -O3 -march=native
+    CFLAGS = -O3
+    ifneq (, $(findstring 86, $(machine)))
+        CFLAGS += -march=native
+    endif
+    ifneq (, $(findstring aarch64, $(machine)))
+        CFLAGS += -mcpu=native
+    endif
 endif
 CFLAGS += -std=gnu11 -I./src
 

--- a/Make.inc
+++ b/Make.inc
@@ -79,11 +79,13 @@ ASM = src/recurrence/recurrence_default.s \
       src/permute/permute_SSE2.s \
       src/permute/permute_AVX.s \
       src/permute/permute_AVX512F.s \
+      src/permute/permute_NEON.s \
       src/rotations/rotations_default.s \
       src/rotations/rotations_SSE2.s \
       src/rotations/rotations_AVX.s \
       src/rotations/rotations_AVX_FMA.s \
-      src/rotations/rotations_AVX512F.s
+      src/rotations/rotations_AVX512F.s \
+      src/rotations/rotations_NEON.s
 
 SRC = src/recurrence.c src/transforms.c src/rotations.c src/permute.c src/tdc.c src/drivers.c src/fftw.c
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 include Make.inc
 
 all:
-	@echo '$(simd)'
 	make assembly
 	make lib
 	make tests

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 include Make.inc
 
 all:
+	@echo '$(simd)'
 	make assembly
 	make lib
 	make tests

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ include Make.inc
 all:
 	@echo '$(simd)'
 	make assembly
-	cat src/recurrence/recurrence_NEON.s
 	make lib
 	make tests
 	make examples
@@ -22,12 +21,14 @@ assembly:
 	$(CC) -S $(AFLAGS) $(MSSE2) src/permute/permute_SSE2.c -o src/permute/permute_SSE2.s
 	$(CC) -S $(AFLAGS) $(MAVX) src/permute/permute_AVX.c -o src/permute/permute_AVX.s
 	$(CC) -S $(AFLAGS) $(MAVX512F) src/permute/permute_AVX512F.c -o src/permute/permute_AVX512F.s
+	$(CC) -S $(AFLAGS) $(MNEON) src/permute/permute_NEON.c -o src/permute/permute_NEON.s
 
 	$(CC) -S $(AFLAGS) src/rotations/rotations_default.c -o src/rotations/rotations_default.s
 	$(CC) -S $(AFLAGS) $(MSSE2) src/rotations/rotations_SSE2.c -o src/rotations/rotations_SSE2.s
 	$(CC) -S $(AFLAGS) $(MAVX) src/rotations/rotations_AVX.c -o src/rotations/rotations_AVX.s
 	$(CC) -S $(AFLAGS) $(MAVX) $(MFMA) src/rotations/rotations_AVX_FMA.c -o src/rotations/rotations_AVX_FMA.s
 	$(CC) -S $(AFLAGS) $(MAVX512F) src/rotations/rotations_AVX512F.c -o src/rotations/rotations_AVX512F.s
+	$(CC) -S $(AFLAGS) $(MNEON) src/rotations/rotations_NEON.c -o src/rotations/rotations_NEON.s
 
 lib:
 	$(CC) $(CFLAGS) $(LIBFLAGS) $(ASM) $(SRC) $(LDFLAGS) $(LDLIBS) -o lib$(LIB).$(SLIB)

--- a/Makefile
+++ b/Makefile
@@ -14,21 +14,21 @@ assembly:
 	$(CC) -S $(AFLAGS) $(MAVX) src/recurrence/recurrence_AVX.c -o src/recurrence/recurrence_AVX.s
 	$(CC) -S $(AFLAGS) $(MAVX) $(MFMA) src/recurrence/recurrence_AVX_FMA.c -o src/recurrence/recurrence_AVX_FMA.s
 	$(CC) -S $(AFLAGS) $(MAVX512F) src/recurrence/recurrence_AVX512F.c -o src/recurrence/recurrence_AVX512F.s
-	$(CC) -S $(AFLAGS) $(MNEON) src/recurrence/recurrence_NEON.c -o src/recurrence/recurrence_NEON.s
+	$(CC) -S $(AFLAGS) src/recurrence/recurrence_NEON.c -o src/recurrence/recurrence_NEON.s
 
 	$(CC) -S $(AFLAGS) src/permute/permute_default.c -o src/permute/permute_default.s
 	$(CC) -S $(AFLAGS) $(MSSE) src/permute/permute_SSE.c -o src/permute/permute_SSE.s
 	$(CC) -S $(AFLAGS) $(MSSE2) src/permute/permute_SSE2.c -o src/permute/permute_SSE2.s
 	$(CC) -S $(AFLAGS) $(MAVX) src/permute/permute_AVX.c -o src/permute/permute_AVX.s
 	$(CC) -S $(AFLAGS) $(MAVX512F) src/permute/permute_AVX512F.c -o src/permute/permute_AVX512F.s
-	$(CC) -S $(AFLAGS) $(MNEON) src/permute/permute_NEON.c -o src/permute/permute_NEON.s
+	$(CC) -S $(AFLAGS) src/permute/permute_NEON.c -o src/permute/permute_NEON.s
 
 	$(CC) -S $(AFLAGS) src/rotations/rotations_default.c -o src/rotations/rotations_default.s
 	$(CC) -S $(AFLAGS) $(MSSE2) src/rotations/rotations_SSE2.c -o src/rotations/rotations_SSE2.s
 	$(CC) -S $(AFLAGS) $(MAVX) src/rotations/rotations_AVX.c -o src/rotations/rotations_AVX.s
 	$(CC) -S $(AFLAGS) $(MAVX) $(MFMA) src/rotations/rotations_AVX_FMA.c -o src/rotations/rotations_AVX_FMA.s
 	$(CC) -S $(AFLAGS) $(MAVX512F) src/rotations/rotations_AVX512F.c -o src/rotations/rotations_AVX512F.s
-	$(CC) -S $(AFLAGS) $(MNEON) src/rotations/rotations_NEON.c -o src/rotations/rotations_NEON.s
+	$(CC) -S $(AFLAGS) src/rotations/rotations_NEON.c -o src/rotations/rotations_NEON.s
 
 lib:
 	$(CC) $(CFLAGS) $(LIBFLAGS) $(ASM) $(SRC) $(LDFLAGS) $(LDLIBS) -o lib$(LIB).$(SLIB)

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ assembly:
 	$(CC) -S $(AFLAGS) $(MAVX) src/recurrence/recurrence_AVX.c -o src/recurrence/recurrence_AVX.s
 	$(CC) -S $(AFLAGS) $(MAVX) $(MFMA) src/recurrence/recurrence_AVX_FMA.c -o src/recurrence/recurrence_AVX_FMA.s
 	$(CC) -S $(AFLAGS) $(MAVX512F) src/recurrence/recurrence_AVX512F.c -o src/recurrence/recurrence_AVX512F.s
+	$(CC) -S $(AFLAGS) $(MNEON) src/recurrence/recurrence_NEON.c -o src/recurrence/recurrence_NEON.s
 
 	$(CC) -S $(AFLAGS) src/permute/permute_default.c -o src/permute/permute_default.s
 	$(CC) -S $(AFLAGS) $(MSSE) src/permute/permute_SSE.c -o src/permute/permute_SSE.s

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ include Make.inc
 all:
 	@echo '$(simd)'
 	make assembly
+	cat src/recurrence/recurrence_NEON.s
 	make lib
 	make tests
 	make examples

--- a/src/drivers.c
+++ b/src/drivers.c
@@ -85,6 +85,8 @@ void ft_execute_sph_hi2lo(const ft_rotation_plan * RP, double * A, double * B, c
     }
     else if (simd.sse2)
         return execute_sph_hi2lo_SSE2(RP, A, B, M);
+    else if (simd.neon)
+        return execute_sph_hi2lo_NEON(RP, A, B, M);
     else
         return execute_sph_hi2lo_default(RP, A, M);
 }
@@ -101,6 +103,8 @@ void ft_execute_sph_lo2hi(const ft_rotation_plan * RP, double * A, double * B, c
     }
     else if (simd.sse2)
         return execute_sph_lo2hi_SSE2(RP, A, B, M);
+    else if (simd.neon)
+        return execute_sph_lo2hi_NEON(RP, A, B, M);
     else
         return execute_sph_lo2hi_default(RP, A, M);
 }
@@ -171,6 +175,13 @@ void execute_sph_lo2hi_AVX512F(const ft_rotation_plan * RP, double * A, double *
     EXECUTE_SPH(8, kernel_sph_lo2hi_default, kernel_sph_lo2hi_AVX512F)
 }
 
+void execute_sph_hi2lo_NEON(const ft_rotation_plan * RP, double * A, double * B, const int M) {
+    EXECUTE_SPH(2, kernel_sph_hi2lo_default, kernel_sph_hi2lo_NEON)
+}
+
+void execute_sph_lo2hi_NEON(const ft_rotation_plan * RP, double * A, double * B, const int M) {
+    EXECUTE_SPH(2, kernel_sph_lo2hi_default, kernel_sph_lo2hi_NEON)
+}
 
 void ft_execute_sphv_hi2lo(const ft_rotation_plan * RP, double * A, double * B, const int M) {
     ft_simd simd = get_simd();
@@ -184,6 +195,8 @@ void ft_execute_sphv_hi2lo(const ft_rotation_plan * RP, double * A, double * B, 
     }
     else if (simd.sse2)
         return execute_sphv_hi2lo_SSE2(RP, A, B, M);
+    else if (simd.neon)
+        return execute_sphv_hi2lo_NEON(RP, A, B, M);
     else
         return execute_sphv_hi2lo_default(RP, A, M);
 }
@@ -200,6 +213,8 @@ void ft_execute_sphv_lo2hi(const ft_rotation_plan * RP, double * A, double * B, 
     }
     else if (simd.sse2)
         return execute_sphv_lo2hi_SSE2(RP, A, B, M);
+    else if (simd.neon)
+        return execute_sphv_lo2hi_NEON(RP, A, B, M);
     else
         return execute_sphv_lo2hi_default(RP, A, M);
 }
@@ -270,6 +285,13 @@ void execute_sphv_lo2hi_AVX512F(const ft_rotation_plan * RP, double * A, double 
     EXECUTE_SPHV(8, kernel_sph_lo2hi_default, kernel_sph_lo2hi_AVX512F)
 }
 
+void execute_sphv_hi2lo_NEON(const ft_rotation_plan * RP, double * A, double * B, const int M) {
+    EXECUTE_SPHV(2, kernel_sph_hi2lo_default, kernel_sph_hi2lo_NEON)
+}
+
+void execute_sphv_lo2hi_NEON(const ft_rotation_plan * RP, double * A, double * B, const int M) {
+    EXECUTE_SPHV(2, kernel_sph_lo2hi_default, kernel_sph_lo2hi_NEON)
+}
 
 void ft_execute_tri_hi2lo(const ft_rotation_plan * RP, double * A, double * B, const int M) {
     ft_simd simd = get_simd();
@@ -283,6 +305,8 @@ void ft_execute_tri_hi2lo(const ft_rotation_plan * RP, double * A, double * B, c
     }
     else if (simd.sse2)
         return execute_tri_hi2lo_SSE2(RP, A, B, M);
+    else if (simd.neon)
+        return execute_tri_hi2lo_NEON(RP, A, B, M);
     else
         return execute_tri_hi2lo_default(RP, A, M);
 }
@@ -299,6 +323,8 @@ void ft_execute_tri_lo2hi(const ft_rotation_plan * RP, double * A, double * B, c
     }
     else if (simd.sse2)
         return execute_tri_lo2hi_SSE2(RP, A, B, M);
+    else if (simd.neon)
+        return execute_tri_lo2hi_NEON(RP, A, B, M);
     else
         return execute_tri_lo2hi_default(RP, A, M);
 }
@@ -359,6 +385,13 @@ void execute_tri_lo2hi_AVX512F(const ft_rotation_plan * RP, double * A, double *
     EXECUTE_TRI(8, kernel_tri_lo2hi_default, kernel_tri_lo2hi_AVX512F)
 }
 
+void execute_tri_hi2lo_NEON(const ft_rotation_plan * RP, double * A, double * B, const int M) {
+    EXECUTE_TRI(2, kernel_tri_hi2lo_default, kernel_tri_hi2lo_NEON)
+}
+
+void execute_tri_lo2hi_NEON(const ft_rotation_plan * RP, double * A, double * B, const int M) {
+    EXECUTE_TRI(2, kernel_tri_lo2hi_default, kernel_tri_lo2hi_NEON)
+}
 
 void ft_execute_disk_hi2lo(const ft_rotation_plan * RP, double * A, double * B, const int M) {
     ft_simd simd = get_simd();
@@ -372,6 +405,8 @@ void ft_execute_disk_hi2lo(const ft_rotation_plan * RP, double * A, double * B, 
     }
     else if (simd.sse2)
         return execute_disk_hi2lo_SSE2(RP, A, B, M);
+    else if (simd.neon)
+        return execute_disk_hi2lo_NEON(RP, A, B, M);
     else
         return execute_disk_hi2lo_default(RP, A, M);
 }
@@ -388,6 +423,8 @@ void ft_execute_disk_lo2hi(const ft_rotation_plan * RP, double * A, double * B, 
     }
     else if (simd.sse2)
         return execute_disk_lo2hi_SSE2(RP, A, B, M);
+    else if (simd.neon)
+        return execute_disk_lo2hi_NEON(RP, A, B, M);
     else
         return execute_disk_lo2hi_default(RP, A, M);
 }
@@ -458,6 +495,13 @@ void execute_disk_lo2hi_AVX512F(const ft_rotation_plan * RP, double * A, double 
     EXECUTE_DISK(8, kernel_disk_lo2hi_default, kernel_disk_lo2hi_AVX512F)
 }
 
+void execute_disk_hi2lo_NEON(const ft_rotation_plan * RP, double * A, double * B, const int M) {
+    EXECUTE_DISK(2, kernel_disk_hi2lo_default, kernel_disk_hi2lo_NEON)
+}
+
+void execute_disk_lo2hi_NEON(const ft_rotation_plan * RP, double * A, double * B, const int M) {
+    EXECUTE_DISK(2, kernel_disk_lo2hi_default, kernel_disk_lo2hi_NEON)
+}
 
 void ft_execute_tet_hi2lo(const ft_rotation_plan * RP1, const ft_rotation_plan * RP2, double * A, const int L, const int M) {
     int N = RP1->n;
@@ -604,6 +648,8 @@ void ft_execute_spinsph_hi2lo(const ft_spin_rotation_plan * SRP, ft_complex * A,
     }
     else if (simd.sse2)
         return execute_spinsph_hi2lo_SSE2(SRP, A, M);
+    else if (simd.neon)
+        return execute_spinsph_hi2lo_NEON(SRP, A, M);
     else
         return execute_spinsph_hi2lo_default(SRP, A, M);
 }
@@ -618,6 +664,8 @@ void ft_execute_spinsph_lo2hi(const ft_spin_rotation_plan * SRP, ft_complex * A,
     }
     else if (simd.sse2)
         return execute_spinsph_lo2hi_SSE2(SRP, A, M);
+    else if (simd.neon)
+        return execute_spinsph_lo2hi_NEON(SRP, A, M);
     else
         return execute_spinsph_lo2hi_default(SRP, A, M);
 }
@@ -718,6 +766,25 @@ void execute_spinsph_lo2hi_AVX_FMA(const ft_spin_rotation_plan * SRP, ft_complex
     permute_t_sph(AD, BD, 2*N, M, 2);
 }
 
+void execute_spinsph_hi2lo_NEON(const ft_spin_rotation_plan * SRP, ft_complex * A, const int M) {
+    int N = SRP->n;
+    kernel_spinsph_hi2lo_NEON(SRP, 0, A, 1);
+    #pragma omp parallel
+    for (int m = 1+FT_GET_THREAD_NUM(); m <= M/2; m += FT_GET_NUM_THREADS()) {
+        kernel_spinsph_hi2lo_NEON(SRP, -m, A + N*(2*m-1), 1);
+        kernel_spinsph_hi2lo_NEON(SRP,  m, A + N*(2*m), 1);
+    }
+}
+
+void execute_spinsph_lo2hi_NEON(const ft_spin_rotation_plan * SRP, ft_complex * A, const int M) {
+    int N = SRP->n;
+    kernel_spinsph_lo2hi_NEON(SRP, 0, A, 1);
+    #pragma omp parallel
+    for (int m = 1+FT_GET_THREAD_NUM(); m <= M/2; m += FT_GET_NUM_THREADS()) {
+        kernel_spinsph_lo2hi_NEON(SRP, -m, A + N*(2*m-1), 1);
+        kernel_spinsph_lo2hi_NEON(SRP,  m, A + N*(2*m), 1);
+    }
+}
 
 void ft_destroy_harmonic_plan(ft_harmonic_plan * P) {
     ft_destroy_rotation_plan(P->RP);

--- a/src/ftinternal.h
+++ b/src/ftinternal.h
@@ -23,6 +23,8 @@
     #include <arm_neon.h>
     #define vall_f32(x) vld1q_dup_f32(&(x))
     #define vall_f64(x) vld1q_dup_f64(&(x))
+    #define vmuladd_f32(a, b, c) vfmaq_f32(c, a, b)
+    #define vmuladd_f64(a, b, c) vfmaq_f64(c, a, b)
 #endif
 
 #define RED(string) "\x1b[31m" string "\x1b[0m"

--- a/src/ftinternal.h
+++ b/src/ftinternal.h
@@ -267,36 +267,42 @@ void horner_SSE2(const int n, const double * c, const int incc, const int m, dou
 void horner_AVX(const int n, const double * c, const int incc, const int m, double * x, double * f);
 void horner_AVX_FMA(const int n, const double * c, const int incc, const int m, double * x, double * f);
 void horner_AVX512F(const int n, const double * c, const int incc, const int m, double * x, double * f);
+void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f);
 
 void horner_defaultf(const int n, const float * c, const int incc, const int m, float * x, float * f);
 void horner_SSEf(const int n, const float * c, const int incc, const int m, float * x, float * f);
 void horner_AVXf(const int n, const float * c, const int incc, const int m, float * x, float * f);
 void horner_AVX_FMAf(const int n, const float * c, const int incc, const int m, float * x, float * f);
 void horner_AVX512Ff(const int n, const float * c, const int incc, const int m, float * x, float * f);
+void horner_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f);
 
 void clenshaw_default(const int n, const double * c, const int incc, const int m, double * x, double * f);
 void clenshaw_SSE2(const int n, const double * c, const int incc, const int m, double * x, double * f);
 void clenshaw_AVX(const int n, const double * c, const int incc, const int m, double * x, double * f);
 void clenshaw_AVX_FMA(const int n, const double * c, const int incc, const int m, double * x, double * f);
 void clenshaw_AVX512F(const int n, const double * c, const int incc, const int m, double * x, double * f);
+void clenshaw_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f);
 
 void clenshaw_defaultf(const int n, const float * c, const int incc, const int m, float * x, float * f);
 void clenshaw_SSEf(const int n, const float * c, const int incc, const int m, float * x, float * f);
 void clenshaw_AVXf(const int n, const float * c, const int incc, const int m, float * x, float * f);
 void clenshaw_AVX_FMAf(const int n, const float * c, const int incc, const int m, float * x, float * f);
 void clenshaw_AVX512Ff(const int n, const float * c, const int incc, const int m, float * x, float * f);
+void clenshaw_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f);
 
 void orthogonal_polynomial_clenshaw_default(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f);
 void orthogonal_polynomial_clenshaw_SSE2(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f);
 void orthogonal_polynomial_clenshaw_AVX(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f);
 void orthogonal_polynomial_clenshaw_AVX_FMA(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f);
 void orthogonal_polynomial_clenshaw_AVX512F(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f);
+void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f);
 
 void orthogonal_polynomial_clenshaw_defaultf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f);
 void orthogonal_polynomial_clenshaw_SSEf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f);
 void orthogonal_polynomial_clenshaw_AVXf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f);
 void orthogonal_polynomial_clenshaw_AVX_FMAf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f);
 void orthogonal_polynomial_clenshaw_AVX512Ff(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f);
+void orthogonal_polynomial_clenshaw_NEONf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f);
 
 double * plan_legendre_to_chebyshev(const int normleg, const int normcheb, const int n);
 double * plan_chebyshev_to_legendre(const int normcheb, const int normleg, const int n);

--- a/src/ftinternal.h
+++ b/src/ftinternal.h
@@ -456,8 +456,8 @@ void execute_spinsph_hi2lo_AVX(const ft_spin_rotation_plan * SRP, ft_complex * A
 void execute_spinsph_lo2hi_AVX(const ft_spin_rotation_plan * SRP, ft_complex * A, ft_complex * B, const int M);
 void execute_spinsph_hi2lo_AVX_FMA(const ft_spin_rotation_plan * SRP, ft_complex * A, ft_complex * B, const int M);
 void execute_spinsph_lo2hi_AVX_FMA(const ft_spin_rotation_plan * SRP, ft_complex * A, ft_complex * B, const int M);
-void execute_spinsph_hi2lo_NEON(const ft_spin_rotation_plan * SRP, ft_complex * A, ft_complex * B, const int M);
-void execute_spinsph_lo2hi_NEON(const ft_spin_rotation_plan * SRP, ft_complex * A, ft_complex * B, const int M);
+void execute_spinsph_hi2lo_NEON(const ft_spin_rotation_plan * SRP, ft_complex * A, const int M);
+void execute_spinsph_lo2hi_NEON(const ft_spin_rotation_plan * SRP, ft_complex * A, const int M);
 
 
 void permute(const double * A, double * B, const int N, const int M, const int L);

--- a/src/ftinternal.h
+++ b/src/ftinternal.h
@@ -333,6 +333,8 @@ void kernel_sph_hi2lo_AVX_FMA(const ft_rotation_plan * RP, const int m1, const i
 void kernel_sph_lo2hi_AVX_FMA(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
 void kernel_sph_hi2lo_AVX512F(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
 void kernel_sph_lo2hi_AVX512F(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
+void kernel_sph_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
+void kernel_sph_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
 
 void kernel_tri_hi2lo_default(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
 void kernel_tri_lo2hi_default(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
@@ -344,6 +346,8 @@ void kernel_tri_hi2lo_AVX_FMA(const ft_rotation_plan * RP, const int m1, const i
 void kernel_tri_lo2hi_AVX_FMA(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
 void kernel_tri_hi2lo_AVX512F(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
 void kernel_tri_lo2hi_AVX512F(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
+void kernel_tri_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
+void kernel_tri_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
 
 void kernel_disk_hi2lo_default(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
 void kernel_disk_lo2hi_default(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
@@ -355,6 +359,8 @@ void kernel_disk_hi2lo_AVX_FMA(const ft_rotation_plan * RP, const int m1, const 
 void kernel_disk_lo2hi_AVX_FMA(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
 void kernel_disk_hi2lo_AVX512F(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
 void kernel_disk_lo2hi_AVX512F(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
+void kernel_disk_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
+void kernel_disk_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S);
 
 void kernel_tet_hi2lo_SSE2(const ft_rotation_plan * RP, const int L, const int m, double * A);
 void kernel_tet_lo2hi_SSE2(const ft_rotation_plan * RP, const int L, const int m, double * A);
@@ -380,6 +386,8 @@ void kernel_spinsph_hi2lo_AVX(const ft_spin_rotation_plan * SRP, const int m, ft
 void kernel_spinsph_lo2hi_AVX(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S);
 void kernel_spinsph_hi2lo_AVX_FMA(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S);
 void kernel_spinsph_lo2hi_AVX_FMA(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S);
+void kernel_spinsph_hi2lo_NEON(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S);
+void kernel_spinsph_lo2hi_NEON(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S);
 
 void execute_sph_hi2lo_default(const ft_rotation_plan * RP, double * A, const int M);
 void execute_sph_lo2hi_default(const ft_rotation_plan * RP, double * A, const int M);
@@ -462,12 +470,14 @@ void swap_warp_default(double * A, double * B, const int N);
 void swap_warp_SSE2(double * A, double * B, const int N);
 void swap_warp_AVX(double * A, double * B, const int N);
 void swap_warp_AVX512F(double * A, double * B, const int N);
+void swap_warp_NEON(double * A, double * B, const int N);
 
 void swap_warpf(float * A, float * B, const int N);
 void swap_warp_defaultf(float * A, float * B, const int N);
 void swap_warp_SSEf(float * A, float * B, const int N);
 void swap_warp_AVXf(float * A, float * B, const int N);
 void swap_warp_AVX512Ff(float * A, float * B, const int N);
+void swap_warp_NEONf(float * A, float * B, const int N);
 
 void warp(double * A, const int N, const int M, const int L);
 void warp_t(double * A, const int N, const int M, const int L);

--- a/src/ftinternal.h
+++ b/src/ftinternal.h
@@ -399,6 +399,8 @@ void execute_sph_hi2lo_AVX_FMA(const ft_rotation_plan * RP, double * A, double *
 void execute_sph_lo2hi_AVX_FMA(const ft_rotation_plan * RP, double * A, double * B, const int M);
 void execute_sph_hi2lo_AVX512F(const ft_rotation_plan * RP, double * A, double * B, const int M);
 void execute_sph_lo2hi_AVX512F(const ft_rotation_plan * RP, double * A, double * B, const int M);
+void execute_sph_hi2lo_NEON(const ft_rotation_plan * RP, double * A, double * B, const int M);
+void execute_sph_lo2hi_NEON(const ft_rotation_plan * RP, double * A, double * B, const int M);
 
 void execute_sphv_hi2lo_default(const ft_rotation_plan * RP, double * A, const int M);
 void execute_sphv_lo2hi_default(const ft_rotation_plan * RP, double * A, const int M);
@@ -410,6 +412,8 @@ void execute_sphv_hi2lo_AVX_FMA(const ft_rotation_plan * RP, double * A, double 
 void execute_sphv_lo2hi_AVX_FMA(const ft_rotation_plan * RP, double * A, double * B, const int M);
 void execute_sphv_hi2lo_AVX512F(const ft_rotation_plan * RP, double * A, double * B, const int M);
 void execute_sphv_lo2hi_AVX512F(const ft_rotation_plan * RP, double * A, double * B, const int M);
+void execute_sphv_hi2lo_NEON(const ft_rotation_plan * RP, double * A, double * B, const int M);
+void execute_sphv_lo2hi_NEON(const ft_rotation_plan * RP, double * A, double * B, const int M);
 
 void execute_tri_hi2lo_default(const ft_rotation_plan * RP, double * A, const int M);
 void execute_tri_lo2hi_default(const ft_rotation_plan * RP, double * A, const int M);
@@ -421,6 +425,8 @@ void execute_tri_hi2lo_AVX_FMA(const ft_rotation_plan * RP, double * A, double *
 void execute_tri_lo2hi_AVX_FMA(const ft_rotation_plan * RP, double * A, double * B, const int M);
 void execute_tri_hi2lo_AVX512F(const ft_rotation_plan * RP, double * A, double * B, const int M);
 void execute_tri_lo2hi_AVX512F(const ft_rotation_plan * RP, double * A, double * B, const int M);
+void execute_tri_hi2lo_NEON(const ft_rotation_plan * RP, double * A, double * B, const int M);
+void execute_tri_lo2hi_NEON(const ft_rotation_plan * RP, double * A, double * B, const int M);
 
 void execute_disk_hi2lo_default(const ft_rotation_plan * RP, double * A, const int M);
 void execute_disk_lo2hi_default(const ft_rotation_plan * RP, double * A, const int M);
@@ -432,6 +438,8 @@ void execute_disk_hi2lo_AVX_FMA(const ft_rotation_plan * RP, double * A, double 
 void execute_disk_lo2hi_AVX_FMA(const ft_rotation_plan * RP, double * A, double * B, const int M);
 void execute_disk_hi2lo_AVX512F(const ft_rotation_plan * RP, double * A, double * B, const int M);
 void execute_disk_lo2hi_AVX512F(const ft_rotation_plan * RP, double * A, double * B, const int M);
+void execute_disk_hi2lo_NEON(const ft_rotation_plan * RP, double * A, double * B, const int M);
+void execute_disk_lo2hi_NEON(const ft_rotation_plan * RP, double * A, double * B, const int M);
 
 void execute_tet_hi2lo_SSE2(const ft_rotation_plan * RP1, const ft_rotation_plan * RP2, double * A, double * B, const int L, const int M);
 void execute_tet_lo2hi_SSE2(const ft_rotation_plan * RP1, const ft_rotation_plan * RP2, double * A, double * B, const int L, const int M);
@@ -448,6 +456,8 @@ void execute_spinsph_hi2lo_AVX(const ft_spin_rotation_plan * SRP, ft_complex * A
 void execute_spinsph_lo2hi_AVX(const ft_spin_rotation_plan * SRP, ft_complex * A, ft_complex * B, const int M);
 void execute_spinsph_hi2lo_AVX_FMA(const ft_spin_rotation_plan * SRP, ft_complex * A, ft_complex * B, const int M);
 void execute_spinsph_lo2hi_AVX_FMA(const ft_spin_rotation_plan * SRP, ft_complex * A, ft_complex * B, const int M);
+void execute_spinsph_hi2lo_NEON(const ft_spin_rotation_plan * SRP, ft_complex * A, ft_complex * B, const int M);
+void execute_spinsph_lo2hi_NEON(const ft_spin_rotation_plan * SRP, ft_complex * A, ft_complex * B, const int M);
 
 
 void permute(const double * A, double * B, const int N, const int M, const int L);

--- a/src/ftinternal.h
+++ b/src/ftinternal.h
@@ -21,8 +21,14 @@
 #endif
 #if defined(__aarch64__)
     #include <arm_neon.h>
-    #define vall_f32(x) vld1q_dup_f32(&(x))
-    #define vall_f64(x) vld1q_dup_f64(&(x))
+    #define vall1_f32(x) vld1q_dup_f32(&(x))
+    #define vall2_f32(x) vld2q_dup_f32(&(x))
+    #define vall3_f32(x) vld3q_dup_f32(&(x))
+    #define vall4_f32(x) vld4q_dup_f32(&(x))
+    #define vall1_f64(x) vld1q_dup_f64(&(x))
+    #define vall2_f64(x) vld2q_dup_f64(&(x))
+    #define vall3_f64(x) vld3q_dup_f64(&(x))
+    #define vall4_f64(x) vld4q_dup_f64(&(x))
 #endif
 
 #define RED(string) "\x1b[31m" string "\x1b[0m"

--- a/src/ftinternal.h
+++ b/src/ftinternal.h
@@ -21,14 +21,8 @@
 #endif
 #if defined(__aarch64__)
     #include <arm_neon.h>
-    #define vall1_f32(x) vld1q_dup_f32(&(x))
-    #define vall2_f32(x) vld2q_dup_f32(&(x))
-    #define vall3_f32(x) vld3q_dup_f32(&(x))
-    #define vall4_f32(x) vld4q_dup_f32(&(x))
-    #define vall1_f64(x) vld1q_dup_f64(&(x))
-    #define vall2_f64(x) vld2q_dup_f64(&(x))
-    #define vall3_f64(x) vld3q_dup_f64(&(x))
-    #define vall4_f64(x) vld4q_dup_f64(&(x))
+    #define vall_f32(x) vld1q_dup_f32(&(x))
+    #define vall_f64(x) vld1q_dup_f64(&(x))
 #endif
 
 #define RED(string) "\x1b[31m" string "\x1b[0m"

--- a/src/ftinternal.h
+++ b/src/ftinternal.h
@@ -19,6 +19,11 @@
         #define bit_AVX512F 0
     #endif
 #endif
+#if defined(__aarch64__)
+    #include <arm_neon.h>
+    #define vall_f32(x) vld1q_dup_f32(&(x))
+    #define vall_f64(x) vld1q_dup_f64(&(x))
+#endif
 
 #define RED(string) "\x1b[31m" string "\x1b[0m"
 #define GREEN(string) "\x1b[32m" string "\x1b[0m"
@@ -132,6 +137,7 @@ typedef struct {
     unsigned avx2    : 1;
     unsigned fma     : 1;
     unsigned avx512f : 1;
+    unsigned neon    : 1;
 } ft_simd;
 
 #if defined(__i386__) || defined(__x86_64__)
@@ -152,10 +158,12 @@ typedef struct {
         unsigned eax1, ebx1, ecx1, edx1;
         cpuid(1, 0, &eax, &ebx, &ecx, &edx);
         cpuid(7, 0, &eax1, &ebx1, &ecx1, &edx1);
-        return (ft_simd) {!!(edx & bit_SSE), !!(edx & bit_SSE2), !!(ecx & bit_SSE3), !!(ecx & bit_SSSE3), !!(ecx & bit_SSE4_1), !!(ecx & bit_SSE4_2), !!(ecx & bit_AVX), !!(ebx1 & bit_AVX2), !!(ecx & bit_FMA), !!(ebx1 & bit_AVX512F)};
+        return (ft_simd) {!!(edx & bit_SSE), !!(edx & bit_SSE2), !!(ecx & bit_SSE3), !!(ecx & bit_SSSE3), !!(ecx & bit_SSE4_1), !!(ecx & bit_SSE4_2), !!(ecx & bit_AVX), !!(ebx1 & bit_AVX2), !!(ecx & bit_FMA), !!(ebx1 & bit_AVX512F), 0};
     }
+#elif defined(__aarch64__)
+    static inline ft_simd get_simd(void) {return (ft_simd) {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};}
 #else
-    static inline ft_simd get_simd(void) {return (ft_simd) {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};}
+    static inline ft_simd get_simd(void) {return (ft_simd) {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};}
 #endif
 
 #ifdef __AVX512F__

--- a/src/ftinternal.h
+++ b/src/ftinternal.h
@@ -25,6 +25,8 @@
     #define vall_f64(x) vld1q_dup_f64(&(x))
     #define vmuladd_f32(a, b, c) vfmaq_f32(c, a, b)
     #define vmuladd_f64(a, b, c) vfmaq_f64(c, a, b)
+    #define vmulsub_f32(a, b, c) (-vfmsq_f32(c, a, b))
+    #define vmulsub_f64(a, b, c) (-vfmsq_f64(c, a, b))
 #endif
 
 #define RED(string) "\x1b[31m" string "\x1b[0m"

--- a/src/permute.c
+++ b/src/permute.c
@@ -80,6 +80,8 @@ void swap_warp(double * A, double * B, const int N) {
         return swap_warp_AVX(A, B, N);
     else if (simd.sse2)
         return swap_warp_SSE2(A, B, N);
+    else if (simd.neon)
+        return swap_warp_NEON(A, B, N);
     else
         return swap_warp_default(A, B, N);
 }
@@ -92,6 +94,8 @@ void swap_warpf(float * A, float * B, const int N) {
         return swap_warp_AVXf(A, B, N);
     else if (simd.sse)
         return swap_warp_SSEf(A, B, N);
+    else if (simd.neon)
+        return swap_warp_NEONf(A, B, N);
     else
         return swap_warp_defaultf(A, B, N);
 }

--- a/src/permute/permute_NEON.c
+++ b/src/permute/permute_NEON.c
@@ -1,0 +1,13 @@
+#include "permute.h"
+
+#ifdef __aarch64__
+    void swap_warp_NEON(double * A, double * B, const int N) {
+        SWAP_WARP_KERNEL(double, float64x2_t, 2, 4, vld1q_f64, vst1q_f64)
+    }
+    void swap_warp_NEONf(float * A, float * B, const int N) {
+        SWAP_WARP_KERNEL(float, float32x4_t, 4, 4, vld1q_f32, vst1q_f32)
+    }
+#else
+    void swap_warp_NEON(double * A, double * B, const int N) {swap_warp_default(A, B, N);}
+    void swap_warp_NEONf(float * A, float * B, const int N) {swap_warp_defaultf(A, B, N);}
+#endif

--- a/src/recurrence.c
+++ b/src/recurrence.c
@@ -13,6 +13,8 @@ void ft_horner(const int n, const double * c, const int incc, const int m, doubl
     }
     else if (simd.sse2)
         return horner_SSE2(n, c, incc, m, x, f);
+    else if (simd.neon)
+        return horner_NEON(n, c, incc, m, x, f);
     else
         return horner_default(n, c, incc, m, x, f);
 }
@@ -29,6 +31,8 @@ void ft_hornerf(const int n, const float * c, const int incc, const int m, float
     }
     else if (simd.sse)
         return horner_SSEf(n, c, incc, m, x, f);
+    else if (simd.neon)
+        return horner_NEONf(n, c, incc, m, x, f);
     else
         return horner_defaultf(n, c, incc, m, x, f);
 }
@@ -45,6 +49,8 @@ void ft_clenshaw(const int n, const double * c, const int incc, const int m, dou
     }
     else if (simd.sse2)
         return clenshaw_SSE2(n, c, incc, m, x, f);
+    else if (simd.neon)
+        return clenshaw_NEON(n, c, incc, m, x, f);
     else
         return clenshaw_default(n, c, incc, m, x, f);
 }
@@ -61,6 +67,8 @@ void ft_clenshawf(const int n, const float * c, const int incc, const int m, flo
     }
     else if (simd.sse)
         return clenshaw_SSEf(n, c, incc, m, x, f);
+    else if (simd.neon)
+        return clenshaw_NEONf(n, c, incc, m, x, f);
     else
         return clenshaw_defaultf(n, c, incc, m, x, f);
 }
@@ -77,6 +85,8 @@ void ft_orthogonal_polynomial_clenshaw(const int n, const double * c, const int 
     }
     else if (simd.sse2)
         return orthogonal_polynomial_clenshaw_SSE2(n, c, incc, A, B, C, m, x, phi0, f);
+    else if (simd.neon)
+        return orthogonal_polynomial_clenshaw_NEON(n, c, incc, A, B, C, m, x, phi0, f);
     else
         return orthogonal_polynomial_clenshaw_default(n, c, incc, A, B, C, m, x, phi0, f);
 }
@@ -93,6 +103,8 @@ void ft_orthogonal_polynomial_clenshawf(const int n, const float * c, const int 
     }
     else if (simd.sse)
         return orthogonal_polynomial_clenshaw_SSEf(n, c, incc, A, B, C, m, x, phi0, f);
+    else if (simd.neon)
+        return orthogonal_polynomial_clenshaw_NEONf(n, c, incc, A, B, C, m, x, phi0, f);
     else
         return orthogonal_polynomial_clenshaw_defaultf(n, c, incc, A, B, C, m, x, phi0, f);
 }

--- a/src/recurrence/recurrence.h
+++ b/src/recurrence/recurrence.h
@@ -29,7 +29,7 @@ for (; j < m; j++) {                                                           \
     f[j] = bk;                                                                 \
 }
 
-#define CLENSHAW_KERNEL(T, VT, S, L, VLOAD, VSTORE, VMULADD)                   \
+#define CLENSHAW_KERNEL(T, VT, S, L, VLOAD, VSTORE, VMULADD, VALL)             \
 if (n < 1) {                                                                   \
     for (int j = 0; j < m; j++)                                                \
         f[j] = 0;                                                              \
@@ -40,16 +40,16 @@ for (; j < m+1-S*L; j += S*L) {                                                \
     VT bk[3*L] = {0};                                                          \
     VT X[L];                                                                   \
     for (int l = 0; l < L; l++)                                                \
-        X[l] = 2*VLOAD(x+j+S*l);                                               \
+        X[l] = VALL((T) 2)*VLOAD(x+j+S*l);                                     \
     for (int k = n-1; k >= 1; k--) {                                           \
         for (int l = 0; l < L; l++) {                                          \
-            bk[3*l] = VMULADD(X[l], bk[3*l+1], c[k*incc] - bk[3*l+2]);         \
+            bk[3*l] = VMULADD(X[l], bk[3*l+1], VALL(c[k*incc]) - bk[3*l+2]);   \
             bk[3*l+2] = bk[3*l+1];                                             \
             bk[3*l+1] = bk[3*l];                                               \
         }                                                                      \
     }                                                                          \
     for (int l = 0; l < L; l++)                                                \
-        VSTORE(f+j+S*l, X[l]/2*bk[3*l+1] + c[0] - bk[3*l+2]);                  \
+        VSTORE(f+j+S*l, X[l]/VALL((T) 2)*bk[3*l+1] + VALL(c[0]) - bk[3*l+2]);  \
 }                                                                              \
 for (; j < m; j++) {                                                           \
     T bk = 0;                                                                  \

--- a/src/recurrence/recurrence.h
+++ b/src/recurrence/recurrence.h
@@ -37,7 +37,7 @@ if (n < 1) {                                                                   \
 }                                                                              \
 int j = 0;                                                                     \
 for (; j < m+1-S*L; j += S*L) {                                                \
-    T TWO = (T) 2;                                                             \
+    T TWO = 2;                                                                 \
     VT bk[3*L] = {0};                                                          \
     VT X[L];                                                                   \
     for (int l = 0; l < L; l++)                                                \

--- a/src/recurrence/recurrence.h
+++ b/src/recurrence/recurrence.h
@@ -37,10 +37,11 @@ if (n < 1) {                                                                   \
 }                                                                              \
 int j = 0;                                                                     \
 for (; j < m+1-S*L; j += S*L) {                                                \
+    T TWO = (T) 2;                                                             \
     VT bk[3*L] = {0};                                                          \
     VT X[L];                                                                   \
     for (int l = 0; l < L; l++)                                                \
-        X[l] = VALL((T) 2)*VLOAD(x+j+S*l);                                     \
+        X[l] = VALL(TWO)*VLOAD(x+j+S*l);                                       \
     for (int k = n-1; k >= 1; k--) {                                           \
         for (int l = 0; l < L; l++) {                                          \
             bk[3*l] = VMULADD(X[l], bk[3*l+1], VALL(c[k*incc]) - bk[3*l+2]);   \
@@ -49,7 +50,7 @@ for (; j < m+1-S*L; j += S*L) {                                                \
         }                                                                      \
     }                                                                          \
     for (int l = 0; l < L; l++)                                                \
-        VSTORE(f+j+S*l, X[l]/VALL((T) 2)*bk[3*l+1] + VALL(c[0]) - bk[3*l+2]);  \
+        VSTORE(f+j+S*l, X[l]/VALL(TWO)*bk[3*l+1] + VALL(c[0]) - bk[3*l+2]);    \
 }                                                                              \
 for (; j < m; j++) {                                                           \
     T bk = 0;                                                                  \

--- a/src/recurrence/recurrence_AVX.c
+++ b/src/recurrence/recurrence_AVX.c
@@ -8,10 +8,10 @@
         HORNER_KERNEL(float, float8, 8, 16, vloadu8f, vstoreu8f, vmuladd, vall8f)
     }
     void clenshaw_AVX(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        CLENSHAW_KERNEL(double, double4, 4, 8, vloadu4, vstoreu4, vmuladd)
+        CLENSHAW_KERNEL(double, double4, 4, 8, vloadu4, vstoreu4, vmuladd, vall4)
     }
     void clenshaw_AVXf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        CLENSHAW_KERNEL(float, float8, 8, 8, vloadu8f, vstoreu8f, vmuladd)
+        CLENSHAW_KERNEL(float, float8, 8, 8, vloadu8f, vstoreu8f, vmuladd, vall8f)
     }
     void orthogonal_polynomial_clenshaw_AVX(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {
         ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, double4, 4, 8, vloadu4, vstoreu4, vmuladd, vmulsub, vall4)

--- a/src/recurrence/recurrence_AVX512F.c
+++ b/src/recurrence/recurrence_AVX512F.c
@@ -8,10 +8,10 @@
         HORNER_KERNEL(float, float16, 16, 8, vloadu16f, vstoreu16f, vfma16f, vall16f)
     }
     void clenshaw_AVX512F(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        CLENSHAW_KERNEL(double, double8, 8, 4, vloadu8, vstoreu8, vfma8)
+        CLENSHAW_KERNEL(double, double8, 8, 4, vloadu8, vstoreu8, vfma8, vall8)
     }
     void clenshaw_AVX512Ff(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        CLENSHAW_KERNEL(float, float16, 16, 4, vloadu16f, vstoreu16f, vfma16f)
+        CLENSHAW_KERNEL(float, float16, 16, 4, vloadu16f, vstoreu16f, vfma16f, vall16f)
     }
     void orthogonal_polynomial_clenshaw_AVX512F(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {
         ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, double8, 8, 4, vloadu8, vstoreu8, vfma8, vfms8, vall8)

--- a/src/recurrence/recurrence_AVX_FMA.c
+++ b/src/recurrence/recurrence_AVX_FMA.c
@@ -9,10 +9,10 @@
             HORNER_KERNEL(float, float8, 8, 8, vloadu8f, vstoreu8f, vfma8f, vall8f)
         }
         void clenshaw_AVX_FMA(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-            CLENSHAW_KERNEL(double, double4, 4, 4, vloadu4, vstoreu4, vfma4)
+            CLENSHAW_KERNEL(double, double4, 4, 4, vloadu4, vstoreu4, vfma4, vall4)
         }
         void clenshaw_AVX_FMAf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-            CLENSHAW_KERNEL(float, float8, 8, 4, vloadu8f, vstoreu8f, vfma8f)
+            CLENSHAW_KERNEL(float, float8, 8, 4, vloadu8f, vstoreu8f, vfma8f, vall8f)
         }
         void orthogonal_polynomial_clenshaw_AVX_FMA(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {
             ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, double4, 4, 4, vloadu4, vstoreu4, vfma4, vfms4, vall4)

--- a/src/recurrence/recurrence_NEON.c
+++ b/src/recurrence/recurrence_NEON.c
@@ -1,0 +1,29 @@
+#include "recurrence.h"
+
+#ifdef __aarch64__
+    void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
+        HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vmuladd, vall_f64)
+    }
+    void horner_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
+        HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
+    }
+    void clenshaw_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
+        CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd)
+    }
+    void clenshaw_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
+        CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vmuladd)
+    }
+    void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64)
+    }
+    void orthogonal_polynomial_clenshaw_NEONf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f) {
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vmuladd, vmulsub, vall_f32)
+    }
+#else
+    void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {horner_default(n, c, incc, m, x, f);}
+    void horner_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {horner_defaultf(n, c, incc, m, x, f);}
+    void clenshaw_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {clenshaw_default(n, c, incc, m, x, f);}
+    void clenshaw_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {clenshaw_defaultf(n, c, incc, m, x, f);}
+    void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {orthogonal_polynomial_clenshaw_default(n, c, incc, A, B, C, m, x, phi0, f);}
+    void orthogonal_polynomial_clenshaw_NEONf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f) {orthogonal_polynomial_clenshaw_defaultf(n, c, incc, A, B, C, m, x, phi0, f);}
+#endif

--- a/src/recurrence/recurrence_NEON.c
+++ b/src/recurrence/recurrence_NEON.c
@@ -2,22 +2,24 @@
 
 #ifdef __aarch64__
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vmuladd, vall_f64)
+        //HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vmuladd, vall1_f64)
+        HORNER_KERNEL(double, float64x2x4_t, 8, 8, vld4q_f64, vst4q_f64, vmuladd, vall4_f64)
     }
     void horner_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
+        //HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmuladd, vall1_f32)
+        HORNER_KERNEL(float, float32x4x4_t, 16, 8, vld4q_f32, vst4q_f32, vmuladd, vall4_f32)
     }
     void clenshaw_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vall_f64)
+        CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vall1_f64)
     }
     void clenshaw_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
+        CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vmuladd, vall1_f32)
     }
     void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {
-        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64)
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall1_f64)
     }
     void orthogonal_polynomial_clenshaw_NEONf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f) {
-        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vmuladd, vmulsub, vall_f32)
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vmuladd, vmulsub, vall1_f32)
     }
 #else
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {horner_default(n, c, incc, m, x, f);}

--- a/src/recurrence/recurrence_NEON.c
+++ b/src/recurrence/recurrence_NEON.c
@@ -2,24 +2,22 @@
 
 #ifdef __aarch64__
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        //HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vmuladd, vall1_f64)
-        HORNER_KERNEL(double, float64x2x4_t, 8, 8, vld4q_f64, vst4q_f64, vmuladd, vall4_f64)
+        HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vmuladd, vall_f64)
     }
     void horner_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        //HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmuladd, vall1_f32)
-        HORNER_KERNEL(float, float32x4x4_t, 16, 8, vld4q_f32, vst4q_f32, vmuladd, vall4_f32)
+        HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
     }
     void clenshaw_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vall1_f64)
+        CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vall_f64)
     }
     void clenshaw_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vmuladd, vall1_f32)
+        CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
     }
     void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {
-        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall1_f64)
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64)
     }
     void orthogonal_polynomial_clenshaw_NEONf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f) {
-        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vmuladd, vmulsub, vall1_f32)
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vmuladd, vmulsub, vall_f32)
     }
 #else
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {horner_default(n, c, incc, m, x, f);}

--- a/src/recurrence/recurrence_NEON.c
+++ b/src/recurrence/recurrence_NEON.c
@@ -2,10 +2,10 @@
 
 #ifdef __aarch64__
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vmuladd, vall_f64)
+        HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vmlaq_f64, vall_f64)
     }
     void horner_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
+        HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmlaq_f32, vall_f32)
     }
     void clenshaw_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
         CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vall_f64)

--- a/src/recurrence/recurrence_NEON.c
+++ b/src/recurrence/recurrence_NEON.c
@@ -2,22 +2,22 @@
 
 #ifdef __aarch64__
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vmuladd, vall_f64)
+        HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vmuladd_f64, vall_f64)
     }
     void horner_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
+        HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmuladd_f32, vall_f32)
     }
     void clenshaw_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vall_f64)
+        CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd_f64, vall_f64)
     }
     void clenshaw_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
+        CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vmuladd_f32, vall_f32)
     }
     void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {
-        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64)
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd_f64, vmulsub, vall_f64)
     }
     void orthogonal_polynomial_clenshaw_NEONf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f) {
-        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vmuladd, vmulsub, vall_f32)
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vmuladd_f32, vmulsub, vall_f32)
     }
 #else
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {horner_default(n, c, incc, m, x, f);}

--- a/src/recurrence/recurrence_NEON.c
+++ b/src/recurrence/recurrence_NEON.c
@@ -5,7 +5,7 @@
         HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vfmaq_f64, vall_f64)
     }
     void horner_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vfmaq_f32, vall_f32)
+        HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
     }
     void clenshaw_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {clenshaw_default(n, c, incc, m, x, f);}
     void clenshaw_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {clenshaw_defaultf(n, c, incc, m, x, f);}

--- a/src/recurrence/recurrence_NEON.c
+++ b/src/recurrence/recurrence_NEON.c
@@ -14,10 +14,10 @@
         CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vmuladd_f32, vall_f32)
     }
     void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {
-        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd_f64, vmulsub, vall_f64)
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd_f64, vmulsub_f64, vall_f64)
     }
     void orthogonal_polynomial_clenshaw_NEONf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f) {
-        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vmuladd_f32, vmulsub, vall_f32)
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vmuladd_f32, vmulsub_f32, vall_f32)
     }
 #else
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {horner_default(n, c, incc, m, x, f);}

--- a/src/recurrence/recurrence_NEON.c
+++ b/src/recurrence/recurrence_NEON.c
@@ -2,22 +2,22 @@
 
 #ifdef __aarch64__
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vmlaq_f64, vall_f64)
+        HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vmuladd, vall_f64)
     }
     void horner_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmlaq_f32, vall_f32)
+        HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
     }
     void clenshaw_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmlaq_f64, vall_f64)
+        CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vall_f64)
     }
     void clenshaw_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vmlaq_f32, vall_f32)
+        CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
     }
     void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {
-        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmlaq_f64, vmulsub, vall_f64)
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64)
     }
     void orthogonal_polynomial_clenshaw_NEONf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f) {
-        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vmlaq_f32, vmulsub, vall_f32)
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vmuladd, vmulsub, vall_f32)
     }
 #else
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {horner_default(n, c, incc, m, x, f);}

--- a/src/recurrence/recurrence_NEON.c
+++ b/src/recurrence/recurrence_NEON.c
@@ -2,10 +2,10 @@
 
 #ifdef __aarch64__
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vmlaq_f64, vall_f64)
+        HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vmuladd, vall_f64)
     }
     void horner_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmlaq_f32, vall_f32)
+        HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
     }
     void clenshaw_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
         CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vall_f64)

--- a/src/recurrence/recurrence_NEON.c
+++ b/src/recurrence/recurrence_NEON.c
@@ -7,17 +7,15 @@
     void horner_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
         HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
     }
-    void clenshaw_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {clenshaw_default(n, c, incc, m, x, f);}
-    void clenshaw_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {clenshaw_defaultf(n, c, incc, m, x, f);}
-    void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {orthogonal_polynomial_clenshaw_default(n, c, incc, A, B, C, m, x, phi0, f);}
-    void orthogonal_polynomial_clenshaw_NEONf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f) {orthogonal_polynomial_clenshaw_defaultf(n, c, incc, A, B, C, m, x, phi0, f);}
-    /*
     void clenshaw_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
         CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vfmaq_f64)
     }
     void clenshaw_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
         CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vfmaq_f32)
     }
+    void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {orthogonal_polynomial_clenshaw_default(n, c, incc, A, B, C, m, x, phi0, f);}
+    void orthogonal_polynomial_clenshaw_NEONf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f) {orthogonal_polynomial_clenshaw_defaultf(n, c, incc, A, B, C, m, x, phi0, f);}
+    /*
     void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {
         ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vfmaq_f64, vfmsq_f64, vall_f64)
     }

--- a/src/recurrence/recurrence_NEON.c
+++ b/src/recurrence/recurrence_NEON.c
@@ -2,7 +2,7 @@
 
 #ifdef __aarch64__
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vfmaq_f64, vall_f64)
+        HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vmuladd, vall_f64)
     }
     void horner_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
         HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmuladd, vall_f32)

--- a/src/recurrence/recurrence_NEON.c
+++ b/src/recurrence/recurrence_NEON.c
@@ -13,16 +13,12 @@
     void clenshaw_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
         CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vfmaq_f32)
     }
-    void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {orthogonal_polynomial_clenshaw_default(n, c, incc, A, B, C, m, x, phi0, f);}
-    void orthogonal_polynomial_clenshaw_NEONf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f) {orthogonal_polynomial_clenshaw_defaultf(n, c, incc, A, B, C, m, x, phi0, f);}
-    /*
     void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {
         ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vfmaq_f64, vfmsq_f64, vall_f64)
     }
     void orthogonal_polynomial_clenshaw_NEONf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f) {
         ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vfmaq_f32, vfmsq_f32, vall_f32)
     }
-    */
 #else
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {horner_default(n, c, incc, m, x, f);}
     void horner_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {horner_defaultf(n, c, incc, m, x, f);}

--- a/src/recurrence/recurrence_NEON.c
+++ b/src/recurrence/recurrence_NEON.c
@@ -2,22 +2,22 @@
 
 #ifdef __aarch64__
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vmuladd, vall_f64)
+        HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vmlaq_f64, vall_f64)
     }
     void horner_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
+        HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmlaq_f32, vall_f32)
     }
     void clenshaw_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vall_f64)
+        CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmlaq_f64, vall_f64)
     }
     void clenshaw_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
+        CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vmlaq_f32, vall_f32)
     }
     void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {
-        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64)
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmlaq_f64, vmulsub, vall_f64)
     }
     void orthogonal_polynomial_clenshaw_NEONf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f) {
-        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vmuladd, vmulsub, vall_f32)
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vmlaq_f32, vmulsub, vall_f32)
     }
 #else
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {horner_default(n, c, incc, m, x, f);}

--- a/src/recurrence/recurrence_NEON.c
+++ b/src/recurrence/recurrence_NEON.c
@@ -8,10 +8,10 @@
         HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
     }
     void clenshaw_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd)
+        CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vall_f64)
     }
     void clenshaw_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vmuladd)
+        CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
     }
     void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {
         ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64)

--- a/src/recurrence/recurrence_NEON.c
+++ b/src/recurrence/recurrence_NEON.c
@@ -8,16 +8,16 @@
         HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
     }
     void clenshaw_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vfmaq_f64)
+        CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd)
     }
     void clenshaw_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vfmaq_f32)
+        CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vmuladd)
     }
     void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {
-        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vfmaq_f64, vfmsq_f64, vall_f64)
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64)
     }
     void orthogonal_polynomial_clenshaw_NEONf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f) {
-        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vfmaq_f32, vfmsq_f32, vall_f32)
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vmuladd, vmulsub, vall_f32)
     }
 #else
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {horner_default(n, c, incc, m, x, f);}

--- a/src/recurrence/recurrence_NEON.c
+++ b/src/recurrence/recurrence_NEON.c
@@ -2,23 +2,29 @@
 
 #ifdef __aarch64__
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vmuladd, vall_f64)
+        HORNER_KERNEL(double, float64x2_t, 2, 16, vld1q_f64, vst1q_f64, vfmaq_f64, vall_f64)
     }
     void horner_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vmuladd, vall_f32)
+        HORNER_KERNEL(float, float32x4_t, 4, 16, vld1q_f32, vst1q_f32, vfmaq_f32, vall_f32)
     }
+    void clenshaw_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {clenshaw_default(n, c, incc, m, x, f);}
+    void clenshaw_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {clenshaw_defaultf(n, c, incc, m, x, f);}
+    void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {orthogonal_polynomial_clenshaw_default(n, c, incc, A, B, C, m, x, phi0, f);}
+    void orthogonal_polynomial_clenshaw_NEONf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f) {orthogonal_polynomial_clenshaw_defaultf(n, c, incc, A, B, C, m, x, phi0, f);}
+    /*
     void clenshaw_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd)
+        CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vfmaq_f64)
     }
     void clenshaw_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vmuladd)
+        CLENSHAW_KERNEL(float, float32x4_t, 4, 8, vld1q_f32, vst1q_f32, vfmaq_f32)
     }
     void orthogonal_polynomial_clenshaw_NEON(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {
-        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64)
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, float64x2_t, 2, 8, vld1q_f64, vst1q_f64, vfmaq_f64, vfmsq_f64, vall_f64)
     }
     void orthogonal_polynomial_clenshaw_NEONf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f) {
-        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vmuladd, vmulsub, vall_f32)
+        ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float32x4_t, 2, 8, vld1q_f32, vst1q_f32, vfmaq_f32, vfmsq_f32, vall_f32)
     }
+    */
 #else
     void horner_NEON(const int n, const double * c, const int incc, const int m, double * x, double * f) {horner_default(n, c, incc, m, x, f);}
     void horner_NEONf(const int n, const float * c, const int incc, const int m, float * x, float * f) {horner_defaultf(n, c, incc, m, x, f);}

--- a/src/recurrence/recurrence_SSE.c
+++ b/src/recurrence/recurrence_SSE.c
@@ -5,7 +5,7 @@
         HORNER_KERNEL(float, float4, 4, 16, vloadu4f, vstoreu4f, vmuladd, vall4f)
     }
     void clenshaw_SSEf(const int n, const float * c, const int incc, const int m, float * x, float * f) {
-        CLENSHAW_KERNEL(float, float4, 4, 8, vloadu4f, vstoreu4f, vmuladd)
+        CLENSHAW_KERNEL(float, float4, 4, 8, vloadu4f, vstoreu4f, vmuladd, vall4f)
     }
     void orthogonal_polynomial_clenshaw_SSEf(const int n, const float * c, const int incc, const float * A, const float * B, const float * C, const int m, float * x, float * phi0, float * f) {
         ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(float, float4, 4, 8, vloadu4f, vstoreu4f, vmuladd, vmulsub, vall4f)

--- a/src/recurrence/recurrence_SSE2.c
+++ b/src/recurrence/recurrence_SSE2.c
@@ -5,7 +5,7 @@
         HORNER_KERNEL(double, double2, 2, 16, vloadu2, vstoreu2, vmuladd, vall2)
     }
     void clenshaw_SSE2(const int n, const double * c, const int incc, const int m, double * x, double * f) {
-        CLENSHAW_KERNEL(double, double2, 2, 8, vloadu2, vstoreu2, vmuladd)
+        CLENSHAW_KERNEL(double, double2, 2, 8, vloadu2, vstoreu2, vmuladd, vall2)
     }
     void orthogonal_polynomial_clenshaw_SSE2(const int n, const double * c, const int incc, const double * A, const double * B, const double * C, const int m, double * x, double * phi0, double * f) {
         ORTHOGONAL_POLYNOMIAL_CLENSHAW_KERNEL(double, double2, 2, 8, vloadu2, vstoreu2, vmuladd, vmulsub, vall2)

--- a/src/rotations/rotations.h
+++ b/src/rotations/rotations.h
@@ -17,8 +17,7 @@
 
 #define KERNEL_SPH_HI2LO(T, VT, VS, L, VLOAD, VSTORE, VMULADD, VMULSUB, VALL, APPLY_GIVENS) \
 int n = RP->n, row, col;                                                       \
-T ts, tc;                                                                      \
-VT X[3*L], T1, T2;                                                             \
+VT X[3*L], TS, TC, T1, T2;                                                     \
 for (int s = 1; s < VS/2; s++) {                                               \
     kernel_sph_hi2lo_default(RP, m2, m2+2*s, A+2*s, S);                        \
     kernel_sph_hi2lo_default(RP, m2, m2+2*s, A+2*s+1, S);                      \
@@ -35,10 +34,10 @@ for (; j >= m1+2*L-2; j -= 2*L) {                                              \
                 col = j-2*lj;                                                  \
                 T1 = X[L-1-lk+2*lj];                                           \
                 T2 = X[L+1-lk+2*lj];                                           \
-                ts = RP->s(row, col);                                          \
-                tc = RP->c(row, col);                                          \
-                X[L-1-lk+2*lj] = VMULADD(VALL(tc), T1, ts*T2);                 \
-                X[L+1-lk+2*lj] = VMULSUB(VALL(tc), T2, ts*T1);                 \
+                TS = VALL(RP->s(row, col));                                    \
+                TC = VALL(RP->c(row, col));                                    \
+                X[L-1-lk+2*lj] = VMULADD(TC, T1, TS*T2);                       \
+                X[L+1-lk+2*lj] = VMULSUB(TC, T2, TS*T1);                       \
             }                                                                  \
         }                                                                      \
         for (int l = 0; l < 3*L; l++)                                          \
@@ -60,8 +59,7 @@ for (; j >= m1; j -= 2) {                                                      \
 
 #define KERNEL_SPH_LO2HI(T, VT, VS, L, VLOAD, VSTORE, VMULADD, VMULSUB, VALL, APPLY_GIVENS_T) \
 int n = RP->n, row, col;                                                       \
-T ts, tc;                                                                      \
-VT X[3*L], T1, T2;                                                             \
+VT X[3*L], TS, TC, T1, T2;                                                     \
 int j = m1;                                                                    \
 for (; j < m2-2*L-2*VS+4; j += 2*L) {                                          \
     int k = 2*L+(n-L-2-j)%L;                                                   \
@@ -81,10 +79,10 @@ for (; j < m2-2*L-2*VS+4; j += 2*L) {                                          \
                 col = j+2*lj;                                                  \
                 T1 = X[2*L-2+lk-2*lj];                                         \
                 T2 = X[2*L+lk-2*lj];                                           \
-                ts = RP->s(row, col);                                          \
-                tc = RP->c(row, col);                                          \
-                X[2*L-2+lk-2*lj] = VMULSUB(VALL(tc), T1, ts*T2);               \
-                X[2*L+lk-2*lj] = VMULADD(VALL(tc), T2, ts*T1);                 \
+                TS = VALL(RP->s(row, col));                                    \
+                TC = VALL(RP->c(row, col));                                    \
+                X[2*L-2+lk-2*lj] = VMULSUB(TC, T1, TS*T2);                     \
+                X[2*L+lk-2*lj] = VMULADD(TC, T2, TS*T1);                       \
             }                                                                  \
         }                                                                      \
         for (int l = 0; l < 3*L; l++)                                          \
@@ -103,8 +101,7 @@ for (int s = 1; s < VS/2; s++) {                                               \
 
 #define KERNEL_TRI_HI2LO(T, VT, VS, L, VLOAD, VSTORE, VMULADD, VMULSUB, VALL, APPLY_GIVENS) \
 int n = RP->n, row, col;                                                       \
-T ts, tc;                                                                      \
-VT X[2*L], T1, T2;                                                             \
+VT X[2*L], TS, TC, T1, T2;                                                     \
 for (int s = 1; s < VS; s++)                                                   \
     kernel_tri_hi2lo_default(RP, m2, m2+s, A+s, S);                            \
 int j = m2-1;                                                                  \
@@ -119,10 +116,10 @@ for (; j >= m1+L-1; j -= L) {                                                  \
                 col = j-lj;                                                    \
                 T1 = X[L-1-lk+lj];                                             \
                 T2 = X[L-lk+lj];                                               \
-                ts = RP->s(row, col);                                          \
-                tc = RP->c(row, col);                                          \
-                X[L-1-lk+lj] = VMULADD(VALL(tc), T1, ts*T2);                   \
-                X[L-lk+lj] = VMULSUB(VALL(tc), T2, ts*T1);                     \
+                TS = VALL(RP->s(row, col));                                    \
+                TC = VALL(RP->c(row, col));                                    \
+                X[L-1-lk+lj] = VMULADD(TC, T1, TS*T2);                         \
+                X[L-lk+lj] = VMULSUB(TC, T2, TS*T1);                           \
             }                                                                  \
         }                                                                      \
         for (int l = 0; l < 2*L; l++)                                          \
@@ -144,8 +141,7 @@ for (; j >= m1; j--) {                                                         \
 
 #define KERNEL_TRI_LO2HI(T, VT, VS, L, VLOAD, VSTORE, VMULADD, VMULSUB, VALL, APPLY_GIVENS_T) \
 int n = RP->n, row, col;                                                       \
-T ts, tc;                                                                      \
-VT X[2*L], T1, T2;                                                             \
+VT X[2*L], TS, TC, T1, T2;                                                     \
 int j = m1;                                                                    \
 for (; j < m2-L-VS+2; j += L) {                                                \
     int k = L+(n-L-1-j)%L;                                                     \
@@ -165,10 +161,10 @@ for (; j < m2-L-VS+2; j += L) {                                                \
                 col = j+lj;                                                    \
                 T1 = X[L-1+lk-lj];                                             \
                 T2 = X[L+lk-lj];                                               \
-                ts = RP->s(row, col);                                          \
-                tc = RP->c(row, col);                                          \
-                X[L-1+lk-lj] = VMULSUB(VALL(tc), T1, ts*T2);                   \
-                X[L+lk-lj] = VMULADD(VALL(tc), T2, ts*T1);                     \
+                TS = VALL(RP->s(row, col));                                    \
+                TC = VALL(RP->c(row, col));                                    \
+                X[L-1+lk-lj] = VMULSUB(TC, T1, TS*T2);                         \
+                X[L+lk-lj] = VMULADD(TC, T2, TS*T1);                           \
             }                                                                  \
         }                                                                      \
         for (int l = 0; l < 2*L; l++)                                          \
@@ -185,8 +181,7 @@ for (int s = 1; s < VS; s++)                                                   \
 
 #define KERNEL_DISK_HI2LO(T, VT, VS, L, VLOAD, VSTORE, VMULADD, VMULSUB, VALL, APPLY_GIVENS) \
 int n = RP->n, row, col;                                                       \
-T ts, tc;                                                                      \
-VT X[2*L], T1, T2;                                                             \
+VT X[2*L], TS, TC, T1, T2;                                                     \
 for (int s = 1; s < VS/2; s++) {                                               \
     kernel_disk_hi2lo_default(RP, m2, m2+2*s, A+2*s, S);                       \
     kernel_disk_hi2lo_default(RP, m2, m2+2*s, A+2*s+1, S);                     \
@@ -203,10 +198,10 @@ for (; j >= m1+2*L-1; j -= 2*L) {                                              \
                 col = j-2*lj;                                                  \
                 T1 = X[L-1-lk+lj];                                             \
                 T2 = X[L-lk+lj];                                               \
-                ts = RP->sd(row, col);                                         \
-                tc = RP->cd(row, col);                                         \
-                X[L-1-lk+lj] = VMULADD(VALL(tc), T1, ts*T2);                   \
-                X[L-lk+lj] = VMULSUB(VALL(tc), T2, ts*T1);                     \
+                TS = VALL(RP->sd(row, col));                                   \
+                TC = VALL(RP->cd(row, col));                                   \
+                X[L-1-lk+lj] = VMULADD(TC, T1, TS*T2);                         \
+                X[L-lk+lj] = VMULSUB(TC, T2, TS*T1);                           \
             }                                                                  \
         }                                                                      \
         for (int l = 0; l < 2*L; l++)                                          \
@@ -228,8 +223,7 @@ for (; j >= m1; j -= 2) {                                                      \
 
 #define KERNEL_DISK_LO2HI(T, VT, VS, L, VLOAD, VSTORE, VMULADD, VMULSUB, VALL, APPLY_GIVENS_T) \
 int n = RP->n, row, col;                                                       \
-T ts, tc;                                                                      \
-VT X[2*L], T1, T2;                                                             \
+VT X[2*L], TS, TC, T1, T2;                                                     \
 int j = m1;                                                                    \
 for (; j < m2-2*L-2*VS+4; j += 2*L) {                                          \
     int k = L+(n-L-1-(j+1)/2)%L;                                               \
@@ -249,10 +243,10 @@ for (; j < m2-2*L-2*VS+4; j += 2*L) {                                          \
                 col = j+2*lj;                                                  \
                 T1 = X[L-1+lk-lj];                                             \
                 T2 = X[L+lk-lj];                                               \
-                ts = RP->sd(row, col);                                         \
-                tc = RP->cd(row, col);                                         \
-                X[L-1+lk-lj] = VMULSUB(VALL(tc), T1, ts*T2);                   \
-                X[L+lk-lj] = VMULADD(VALL(tc), T2, ts*T1);                     \
+                TS = VALL(RP->sd(row, col));                                   \
+                TC = VALL(RP->cd(row, col));                                   \
+                X[L-1+lk-lj] = VMULSUB(TC, T1, TS*T2);                         \
+                X[L+lk-lj] = VMULADD(TC, T2, TS*T1);                           \
             }                                                                  \
         }                                                                      \
         for (int l = 0; l < 2*L; l++)                                          \

--- a/src/rotations/rotations_AVX.c
+++ b/src/rotations/rotations_AVX.c
@@ -108,4 +108,34 @@
         kernel_disk_lo2hi_SSE2(RP, m1, m2, A, S);
         kernel_disk_lo2hi_SSE2(RP, m1, m2+2, A+2, S);
     }
+    void kernel_spinsph_hi2lo_AVX(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S) {
+        double t;
+        for (int i = 0; i < SRP->n; i++) {
+            t = A[i*S][1];
+            A[i*S][1] = A[i*S+1][0];
+            A[i*S+1][0] = t;
+        }
+        kernel_spinsph_hi2lo_SSE2(SRP, -m, A, S);
+        kernel_spinsph_hi2lo_SSE2(SRP, m, A+1, S);
+        for (int i = 0; i < SRP->n; i++) {
+            t = A[i*S][1];
+            A[i*S][1] = A[i*S+1][0];
+            A[i*S+1][0] = t;
+        }
+    }
+    void kernel_spinsph_lo2hi_AVX(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S) {
+        double t;
+        for (int i = 0; i < SRP->n; i++) {
+            t = A[i*S][1];
+            A[i*S][1] = A[i*S+1][0];
+            A[i*S+1][0] = t;
+        }
+        kernel_spinsph_lo2hi_SSE2(SRP, -m, A, S);
+        kernel_spinsph_lo2hi_SSE2(SRP, m, A+1, S);
+        for (int i = 0; i < SRP->n; i++) {
+            t = A[i*S][1];
+            A[i*S][1] = A[i*S+1][0];
+            A[i*S+1][0] = t;
+        }
+    }
 #endif

--- a/src/rotations/rotations_AVX_FMA.c
+++ b/src/rotations/rotations_AVX_FMA.c
@@ -135,4 +135,34 @@
         kernel_disk_lo2hi_SSE2(RP, m1, m2, A, S);
         kernel_disk_lo2hi_SSE2(RP, m1, m2+2, A+2, S);
     }
+    void kernel_spinsph_hi2lo_AVX_FMA(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S) {
+        double t;
+        for (int i = 0; i < SRP->n; i++) {
+            t = A[i*S][1];
+            A[i*S][1] = A[i*S+1][0];
+            A[i*S+1][0] = t;
+        }
+        kernel_spinsph_hi2lo_SSE2(SRP, -m, A, S);
+        kernel_spinsph_hi2lo_SSE2(SRP, m, A+1, S);
+        for (int i = 0; i < SRP->n; i++) {
+            t = A[i*S][1];
+            A[i*S][1] = A[i*S+1][0];
+            A[i*S+1][0] = t;
+        }
+    }
+    void kernel_spinsph_lo2hi_AVX_FMA(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S) {
+        double t;
+        for (int i = 0; i < SRP->n; i++) {
+            t = A[i*S][1];
+            A[i*S][1] = A[i*S+1][0];
+            A[i*S+1][0] = t;
+        }
+        kernel_spinsph_lo2hi_SSE2(SRP, -m, A, S);
+        kernel_spinsph_lo2hi_SSE2(SRP, m, A+1, S);
+        for (int i = 0; i < SRP->n; i++) {
+            t = A[i*S][1];
+            A[i*S][1] = A[i*S+1][0];
+            A[i*S+1][0] = t;
+        }
+    }
 #endif

--- a/src/rotations/rotations_NEON.c
+++ b/src/rotations/rotations_NEON.c
@@ -20,22 +20,22 @@
         apply_givens_t_NEON(S, C, (double *) X, (double *) Y);
     }
     void kernel_sph_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_SPH_HI2LO(double, double2, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
+        KERNEL_SPH_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
     }
     void kernel_sph_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_SPH_LO2HI(double, double2, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
+        KERNEL_SPH_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
     }
     void kernel_tri_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_TRI_HI2LO(double, double2, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
+        KERNEL_TRI_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
     }
     void kernel_tri_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_TRI_LO2HI(double, double2, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
+        KERNEL_TRI_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
     }
     void kernel_disk_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_DISK_HI2LO(double, double2, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
+        KERNEL_DISK_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
     }
     void kernel_disk_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_DISK_LO2HI(double, double2, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
+        KERNEL_DISK_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
     }
     void kernel_spinsph_hi2lo_NEON(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S) {
         int n = SRP->n, s = SRP->s;

--- a/src/rotations/rotations_NEON.c
+++ b/src/rotations/rotations_NEON.c
@@ -4,14 +4,14 @@
     static inline void apply_givens_NEON(const double S, const double C, double * X, double * Y) {
         float64x2_t x = vld1q_f64(X);
         float64x2_t y = vld1q_f64(Y);
-        vst1q_f64(X, vall_f64(C)*x + vall_f64(S)*y);
-        vst1q_f64(Y, vall_f64(C)*y - vall_f64(S)*x);
+        vst1q_f64(X, vmuladd_f64(vall_f64(C), x, vall_f64(S)*y));
+        vst1q_f64(Y, vmulsub_f64(vall_f64(C), y, vall_f64(S)*x));
     }
     static inline void apply_givens_t_NEON(const double S, const double C, double * X, double * Y) {
         float64x2_t x = vld1q_f64(X);
         float64x2_t y = vld1q_f64(Y);
-        vst1q_f64(X, vall_f64(C)*x - vall_f64(S)*y);
-        vst1q_f64(Y, vall_f64(C)*y + vall_f64(S)*x);
+        vst1q_f64(X, vmulsub_f64(vall_f64(C), x, vall_f64(S)*y));
+        vst1q_f64(Y, vmuladd_f64(vall_f64(C), y, vall_f64(S)*x));
     }
     static inline void apply_givens_NEONc(const double S, const double C, ft_complex * X, ft_complex * Y) {
         apply_givens_NEON(S, C, (double *) X, (double *) Y);
@@ -20,22 +20,22 @@
         apply_givens_t_NEON(S, C, (double *) X, (double *) Y);
     }
     void kernel_sph_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_SPH_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
+        KERNEL_SPH_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd_f64, vmulsub_f64, vall_f64, apply_givens_NEON)
     }
     void kernel_sph_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_SPH_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
+        KERNEL_SPH_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd_f64, vmulsub_f64, vall_f64, apply_givens_t_NEON)
     }
     void kernel_tri_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_TRI_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
+        KERNEL_TRI_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd_f64, vmulsub_f64, vall_f64, apply_givens_NEON)
     }
     void kernel_tri_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_TRI_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
+        KERNEL_TRI_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd_f64, vmulsub_f64, vall_f64, apply_givens_t_NEON)
     }
     void kernel_disk_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_DISK_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
+        KERNEL_DISK_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd_f64, vmulsub_f64, vall_f64, apply_givens_NEON)
     }
     void kernel_disk_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_DISK_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
+        KERNEL_DISK_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd_f64, vmulsub_f64, vall_f64, apply_givens_t_NEON)
     }
     void kernel_spinsph_hi2lo_NEON(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S) {
         int n = SRP->n, s = SRP->s;

--- a/src/rotations/rotations_NEON.c
+++ b/src/rotations/rotations_NEON.c
@@ -4,14 +4,14 @@
     static inline void apply_givens_NEON(const double S, const double C, double * X, double * Y) {
         float64x2_t x = vld1q_f64(X);
         float64x2_t y = vld1q_f64(Y);
-        vst1q_f64(X, vall1_f64(C)*x + vall1_f64(S)*y);
-        vst1q_f64(Y, vall1_f64(C)*y - vall1_f64(S)*x);
+        vst1q_f64(X, vall_f64(C)*x + vall_f64(S)*y);
+        vst1q_f64(Y, vall_f64(C)*y - vall_f64(S)*x);
     }
     static inline void apply_givens_t_NEON(const double S, const double C, double * X, double * Y) {
         float64x2_t x = vld1q_f64(X);
         float64x2_t y = vld1q_f64(Y);
-        vst1q_f64(X, vall1_f64(C)*x - vall1_f64(S)*y);
-        vst1q_f64(Y, vall1_f64(C)*y + vall1_f64(S)*x);
+        vst1q_f64(X, vall_f64(C)*x - vall_f64(S)*y);
+        vst1q_f64(Y, vall_f64(C)*y + vall_f64(S)*x);
     }
     static inline void apply_givens_NEONc(const double S, const double C, ft_complex * X, ft_complex * Y) {
         apply_givens_NEON(S, C, (double *) X, (double *) Y);
@@ -20,22 +20,22 @@
         apply_givens_t_NEON(S, C, (double *) X, (double *) Y);
     }
     void kernel_sph_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_SPH_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall1_f64, apply_givens_NEON)
+        KERNEL_SPH_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
     }
     void kernel_sph_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_SPH_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall1_f64, apply_givens_t_NEON)
+        KERNEL_SPH_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
     }
     void kernel_tri_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_TRI_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall1_f64, apply_givens_NEON)
+        KERNEL_TRI_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
     }
     void kernel_tri_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_TRI_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall1_f64, apply_givens_t_NEON)
+        KERNEL_TRI_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
     }
     void kernel_disk_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_DISK_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall1_f64, apply_givens_NEON)
+        KERNEL_DISK_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
     }
     void kernel_disk_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_DISK_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall1_f64, apply_givens_t_NEON)
+        KERNEL_DISK_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
     }
     void kernel_spinsph_hi2lo_NEON(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S) {
         int n = SRP->n, s = SRP->s;

--- a/src/rotations/rotations_NEON.c
+++ b/src/rotations/rotations_NEON.c
@@ -4,14 +4,14 @@
     static inline void apply_givens_NEON(const double S, const double C, double * X, double * Y) {
         float64x2_t x = vld1q_f64(X);
         float64x2_t y = vld1q_f64(Y);
-        vst1q_f64(X, vall_f64(C)*x + vall_f64(S)*y);
-        vst1q_f64(Y, vall_f64(C)*y - vall_f64(S)*x);
+        vst1q_f64(X, vall1_f64(C)*x + vall1_f64(S)*y);
+        vst1q_f64(Y, vall1_f64(C)*y - vall1_f64(S)*x);
     }
     static inline void apply_givens_t_NEON(const double S, const double C, double * X, double * Y) {
         float64x2_t x = vld1q_f64(X);
         float64x2_t y = vld1q_f64(Y);
-        vst1q_f64(X, vall_f64(C)*x - vall_f64(S)*y);
-        vst1q_f64(Y, vall_f64(C)*y + vall_f64(S)*x);
+        vst1q_f64(X, vall1_f64(C)*x - vall1_f64(S)*y);
+        vst1q_f64(Y, vall1_f64(C)*y + vall1_f64(S)*x);
     }
     static inline void apply_givens_NEONc(const double S, const double C, ft_complex * X, ft_complex * Y) {
         apply_givens_NEON(S, C, (double *) X, (double *) Y);
@@ -20,22 +20,22 @@
         apply_givens_t_NEON(S, C, (double *) X, (double *) Y);
     }
     void kernel_sph_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_SPH_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
+        KERNEL_SPH_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall1_f64, apply_givens_NEON)
     }
     void kernel_sph_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_SPH_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
+        KERNEL_SPH_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall1_f64, apply_givens_t_NEON)
     }
     void kernel_tri_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_TRI_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
+        KERNEL_TRI_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall1_f64, apply_givens_NEON)
     }
     void kernel_tri_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_TRI_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
+        KERNEL_TRI_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall1_f64, apply_givens_t_NEON)
     }
     void kernel_disk_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_DISK_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
+        KERNEL_DISK_HI2LO(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall1_f64, apply_givens_NEON)
     }
     void kernel_disk_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
-        KERNEL_DISK_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
+        KERNEL_DISK_LO2HI(double, float64x2_t, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall1_f64, apply_givens_t_NEON)
     }
     void kernel_spinsph_hi2lo_NEON(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S) {
         int n = SRP->n, s = SRP->s;

--- a/src/rotations/rotations_NEON.c
+++ b/src/rotations/rotations_NEON.c
@@ -1,0 +1,101 @@
+#include "rotations.h"
+
+#ifdef __aarch64__
+    static inline void apply_givens_NEON(const double S, const double C, double * X, double * Y) {
+        float64x2_t x = vld1q_f64(X);
+        float64x2_t y = vld1q_f64(Y);
+        vst1q_f64(X, vall_f64(C)*x + vall_f64(S)*y);
+        vst1q_f64(Y, vall_f64(C)*y - vall_f64(S)*x);
+    }
+    static inline void apply_givens_t_NEON(const double S, const double C, double * X, double * Y) {
+        float64x2_t x = vld1q_f64(X);
+        float64x2_t y = vld1q_f64(Y);
+        vst1q_f64(X, vall_f64(C)*x - vall_f64(S)*y);
+        vst1q_f64(Y, vall_f64(C)*y + vall_f64(S)*x);
+    }
+    static inline void apply_givens_NEONc(const double S, const double C, ft_complex * X, ft_complex * Y) {
+        apply_givens_NEON(S, C, (double *) X, (double *) Y);
+    }
+    static inline void apply_givens_t_NEONc(const double S, const double C, ft_complex * X, ft_complex * Y) {
+        apply_givens_t_NEON(S, C, (double *) X, (double *) Y);
+    }
+    void kernel_sph_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
+        KERNEL_SPH_HI2LO(double, double2, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
+    }
+    void kernel_sph_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
+        KERNEL_SPH_LO2HI(double, double2, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
+    }
+    void kernel_tri_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
+        KERNEL_TRI_HI2LO(double, double2, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
+    }
+    void kernel_tri_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
+        KERNEL_TRI_LO2HI(double, double2, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
+    }
+    void kernel_disk_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
+        KERNEL_DISK_HI2LO(double, double2, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_NEON)
+    }
+    void kernel_disk_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
+        KERNEL_DISK_LO2HI(double, double2, 2, 3, vld1q_f64, vst1q_f64, vmuladd, vmulsub, vall_f64, apply_givens_t_NEON)
+    }
+    void kernel_spinsph_hi2lo_NEON(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S) {
+        int n = SRP->n, s = SRP->s;
+        int as = abs(s), am = abs(m);
+        if (m*s >= 0)
+            for (int j = MIN(am, as)-1; j >= 0; j--)
+                for (int k = n-2-abs(am-as)-j; k >= 0; k--)
+                    apply_givens_NEONc(SRP->s2(k, j, abs(am-as)), SRP->c2(k, j, abs(am-as)), A+k*S, A+(k+1)*S);
+        else
+            for (int j = MIN(am, as)-1; j >= 0; j--)
+                for (int k = n-2-abs(am-as)-j; k >= 0; k--)
+                    apply_givens_t_NEONc(SRP->s2(k, j, abs(am-as)), SRP->c2(k, j, abs(am-as)), A+k*S, A+(k+1)*S);
+        for (int j = abs(am-as)-2; j >= (am+as)%2; j -= 2)
+            for (int k = n-3-j; k >= 0; k--)
+                apply_givens_NEONc(SRP->s1(k, j), SRP->c1(k, j), A+k*S, A+(k+2)*S);
+    }
+    void kernel_spinsph_lo2hi_NEON(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S) {
+        int n = SRP->n, s = SRP->s;
+        int as = abs(s), am = abs(m);
+        for (int j = (am+as)%2; j <= abs(am-as)-2; j += 2)
+            for (int k = 0; k <= n-3-j; k++)
+                apply_givens_t_NEONc(SRP->s1(k, j), SRP->c1(k, j), A+k*S, A+(k+2)*S);
+        if (m*s >= 0)
+            for (int j = 0; j < MIN(am, as); j++)
+                for (int k = 0; k <= n-2-abs(am-as)-j; k++)
+                    apply_givens_t_NEONc(SRP->s2(k, j, abs(am-as)), SRP->c2(k, j, abs(am-as)), A+k*S, A+(k+1)*S);
+        else
+            for (int j = 0; j < MIN(am, as); j++)
+                for (int k = 0; k <= n-2-abs(am-as)-j; k++)
+                    apply_givens_NEONc(SRP->s2(k, j, abs(am-as)), SRP->c2(k, j, abs(am-as)), A+k*S, A+(k+1)*S);
+    }
+#else
+    void kernel_sph_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
+        kernel_sph_hi2lo_default(RP, m1, m2, A, S);
+        kernel_sph_hi2lo_default(RP, m1, m2, A+1, S);
+    }
+    void kernel_sph_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
+        kernel_sph_lo2hi_default(RP, m1, m2, A, S);
+        kernel_sph_lo2hi_default(RP, m1, m2, A+1, S);
+    }
+    void kernel_tri_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
+        kernel_tri_hi2lo_default(RP, m1, m2, A, S);
+        kernel_tri_hi2lo_default(RP, m1, m2+1, A+1, S);
+    }
+    void kernel_tri_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
+        kernel_tri_lo2hi_default(RP, m1, m2, A, S);
+        kernel_tri_lo2hi_default(RP, m1, m2+1, A+1, S);
+    }
+    void kernel_disk_hi2lo_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
+        kernel_disk_hi2lo_default(RP, m1, m2, A, S);
+        kernel_disk_hi2lo_default(RP, m1, m2, A+1, S);
+    }
+    void kernel_disk_lo2hi_NEON(const ft_rotation_plan * RP, const int m1, const int m2, double * A, const int S) {
+        kernel_disk_lo2hi_default(RP, m1, m2, A, S);
+        kernel_disk_lo2hi_default(RP, m1, m2, A+1, S);
+    }
+    void kernel_spinsph_hi2lo_NEON(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S) {
+        kernel_spinsph_hi2lo_default(SRP, m, A, S);
+    }
+    void kernel_spinsph_lo2hi_NEON(const ft_spin_rotation_plan * SRP, const int m, ft_complex * A, const int S) {
+        kernel_spinsph_lo2hi_default(SRP, m, A, S);
+    }
+#endif

--- a/test/test_drivers.c
+++ b/test/test_drivers.c
@@ -57,85 +57,107 @@ int main(int argc, const char * argv[]) {
         printf("ϵ_∞ default-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
         ft_checktest(err, 2*N, &checksum);
 
-        execute_sph_hi2lo_SSE2(RP, A, Ac, M);
-        execute_sph_lo2hi_default(RP, A, M);
+        #if defined(__i386__) || defined(__x86_64__)
+            execute_sph_hi2lo_SSE2(RP, A, Ac, M);
+            execute_sph_lo2hi_default(RP, A, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 SSE2-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ SSE2-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 SSE2-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ SSE2-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_sph_hi2lo_default(RP, A, M);
-        execute_sph_lo2hi_SSE2(RP, A, Ac, M);
+            execute_sph_hi2lo_default(RP, A, M);
+            execute_sph_lo2hi_SSE2(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 default-SSE2 \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ default-SSE2 \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 default-SSE2 \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ default-SSE2 \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_sph_hi2lo_AVX(RP, A, Ac, M);
-        execute_sph_lo2hi_SSE2(RP, A, Ac, M);
+            execute_sph_hi2lo_AVX(RP, A, Ac, M);
+            execute_sph_lo2hi_SSE2(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX-SSE2 \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX-SSE2 \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX-SSE2 \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX-SSE2 \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_sph_hi2lo_SSE2(RP, A, Ac, M);
-        execute_sph_lo2hi_AVX(RP, A, Ac, M);
+            execute_sph_hi2lo_SSE2(RP, A, Ac, M);
+            execute_sph_lo2hi_AVX(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 SSE2-AVX \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ SSE2-AVX \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 SSE2-AVX \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ SSE2-AVX \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_sph_hi2lo_AVX_FMA(RP, A, Ac, M);
-        execute_sph_lo2hi_AVX(RP, A, Ac, M);
+            execute_sph_hi2lo_AVX_FMA(RP, A, Ac, M);
+            execute_sph_lo2hi_AVX(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX_FMA-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX_FMA-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX_FMA-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX_FMA-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_sph_hi2lo_AVX(RP, A, Ac, M);
-        execute_sph_lo2hi_AVX_FMA(RP, A, Ac, M);
+            execute_sph_hi2lo_AVX(RP, A, Ac, M);
+            execute_sph_lo2hi_AVX_FMA(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_sph_hi2lo_AVX512F(RP, A, Ac, M);
-        execute_sph_lo2hi_AVX_FMA(RP, A, Ac, M);
+            execute_sph_hi2lo_AVX512F(RP, A, Ac, M);
+            execute_sph_lo2hi_AVX_FMA(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX512F-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX512F-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX512F-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX512F-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_sph_hi2lo_AVX_FMA(RP, A, Ac, M);
-        execute_sph_lo2hi_AVX512F(RP, A, Ac, M);
+            execute_sph_hi2lo_AVX_FMA(RP, A, Ac, M);
+            execute_sph_lo2hi_AVX512F(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX_FMA-AVX512F \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX_FMA-AVX512F \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX_FMA-AVX512F \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX_FMA-AVX512F \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
+        #elif defined(__aarch64__)
+            execute_sph_hi2lo_NEON(RP, A, Ac, M);
+            execute_sph_lo2hi_default(RP, A, M);
+
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 NEON-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ NEON-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
+
+            execute_sph_hi2lo_default(RP, A, M);
+            execute_sph_lo2hi_NEON(RP, A, Ac, M);
+
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 default-NEON \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ default-NEON \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
+        #endif
 
         free(A);
         VFREE(Ac);
@@ -160,30 +182,39 @@ int main(int argc, const char * argv[]) {
         FT_TIME(execute_sph_lo2hi_default(RP, A, M), start, end, NTIMES)
         printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_sph_hi2lo_SSE2(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+        #if defined(__i386__) || defined(__x86_64__)
+            FT_TIME(execute_sph_hi2lo_SSE2(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_sph_lo2hi_SSE2(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_sph_lo2hi_SSE2(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_sph_hi2lo_AVX(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_sph_hi2lo_AVX(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_sph_lo2hi_AVX(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_sph_lo2hi_AVX(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_sph_hi2lo_AVX_FMA(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_sph_hi2lo_AVX_FMA(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_sph_lo2hi_AVX_FMA(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_sph_lo2hi_AVX_FMA(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_sph_hi2lo_AVX512F(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_sph_hi2lo_AVX512F(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_sph_lo2hi_AVX512F(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f\n", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_sph_lo2hi_AVX512F(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
+        #elif defined(__aarch64__)
+            FT_TIME(execute_sph_hi2lo_SSE2(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
+            FT_TIME(execute_sph_lo2hi_SSE2(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
+        #endif
+
+        printf("\n");
         free(A);
         VFREE(B);
         ft_destroy_rotation_plan(RP);
@@ -230,8 +261,9 @@ int main(int argc, const char * argv[]) {
         printf("%d  %.6f", N, elapsed(&start, &end, NTIMES));
 
         FT_TIME(ft_execute_fourier2sph(P, A, N, M), start, end, NTIMES)
-        printf("  %.6f\n", elapsed(&start, &end, NTIMES));
+        printf("  %.6f", elapsed(&start, &end, NTIMES));
 
+        printf("\n");
         free(A);
         ft_destroy_harmonic_plan(P);
     }
@@ -259,85 +291,107 @@ int main(int argc, const char * argv[]) {
         printf("ϵ_∞ default-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
         ft_checktest(err, 2*N, &checksum);
 
-        execute_sphv_hi2lo_SSE2(RP, A, Ac, M);
-        execute_sphv_lo2hi_default(RP, A, M);
+        #if defined(__i386__) || defined(__x86_64__)
+            execute_sphv_hi2lo_SSE2(RP, A, Ac, M);
+            execute_sphv_lo2hi_default(RP, A, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 SSE2-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ SSE2-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 SSE2-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ SSE2-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_sphv_hi2lo_default(RP, A, M);
-        execute_sphv_lo2hi_SSE2(RP, A, Ac, M);
+            execute_sphv_hi2lo_default(RP, A, M);
+            execute_sphv_lo2hi_SSE2(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 default-SSE2 \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ default-SSE2 \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 default-SSE2 \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ default-SSE2 \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_sphv_hi2lo_AVX(RP, A, Ac, M);
-        execute_sphv_lo2hi_SSE2(RP, A, Ac, M);
+            execute_sphv_hi2lo_AVX(RP, A, Ac, M);
+            execute_sphv_lo2hi_SSE2(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX-SSE2 \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX-SSE2 \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX-SSE2 \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX-SSE2 \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_sphv_hi2lo_SSE2(RP, A, Ac, M);
-        execute_sphv_lo2hi_AVX(RP, A, Ac, M);
+            execute_sphv_hi2lo_SSE2(RP, A, Ac, M);
+            execute_sphv_lo2hi_AVX(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 SSE2-AVX \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ SSE2-AVX \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 SSE2-AVX \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ SSE2-AVX \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_sphv_hi2lo_AVX_FMA(RP, A, Ac, M);
-        execute_sphv_lo2hi_AVX(RP, A, Ac, M);
+            execute_sphv_hi2lo_AVX_FMA(RP, A, Ac, M);
+            execute_sphv_lo2hi_AVX(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX_FMA-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX_FMA-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX_FMA-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX_FMA-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_sphv_hi2lo_AVX(RP, A, Ac, M);
-        execute_sphv_lo2hi_AVX_FMA(RP, A, Ac, M);
+            execute_sphv_hi2lo_AVX(RP, A, Ac, M);
+            execute_sphv_lo2hi_AVX_FMA(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_sphv_hi2lo_AVX512F(RP, A, Ac, M);
-        execute_sphv_lo2hi_AVX(RP, A, Ac, M);
+            execute_sphv_hi2lo_AVX512F(RP, A, Ac, M);
+            execute_sphv_lo2hi_AVX(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX512F-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX512F-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX512F-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX512F-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_sphv_hi2lo_AVX(RP, A, Ac, M);
-        execute_sphv_lo2hi_AVX512F(RP, A, Ac, M);
+            execute_sphv_hi2lo_AVX(RP, A, Ac, M);
+            execute_sphv_lo2hi_AVX512F(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX-AVX512F \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX-AVX512F \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX-AVX512F \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX-AVX512F \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
+        #elif defined(__aarch64__)
+            execute_sphv_hi2lo_NEON(RP, A, Ac, M);
+            execute_sphv_lo2hi_default(RP, A, M);
+
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 NEON-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ NEON-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
+
+            execute_sphv_hi2lo_default(RP, A, M);
+            execute_sphv_lo2hi_NEON(RP, A, Ac, M);
+
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 default-NEON \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ default-NEON \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
+        #endif
 
         free(A);
         VFREE(Ac);
@@ -362,30 +416,39 @@ int main(int argc, const char * argv[]) {
         FT_TIME(execute_sphv_lo2hi_default(RP, A, M), start, end, NTIMES)
         printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_sphv_hi2lo_SSE2(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+        #if defined(__i386__) || defined(__x86_64__)
+            FT_TIME(execute_sphv_hi2lo_SSE2(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_sphv_lo2hi_SSE2(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_sphv_lo2hi_SSE2(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_sphv_hi2lo_AVX(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_sphv_hi2lo_AVX(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_sphv_lo2hi_AVX(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_sphv_lo2hi_AVX(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_sphv_hi2lo_AVX_FMA(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_sphv_hi2lo_AVX_FMA(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_sphv_lo2hi_AVX_FMA(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_sphv_lo2hi_AVX_FMA(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_sphv_hi2lo_AVX512F(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_sphv_hi2lo_AVX512F(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_sphv_lo2hi_AVX512F(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f\n", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_sphv_lo2hi_AVX512F(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
+        #elif defined(__aarch64__)
+            FT_TIME(execute_sphv_hi2lo_NEON(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
+            FT_TIME(execute_sphv_lo2hi_NEON(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
+        #endif
+
+        printf("\n");
         free(A);
         VFREE(B);
         ft_destroy_rotation_plan(RP);
@@ -432,8 +495,9 @@ int main(int argc, const char * argv[]) {
         printf("%d  %.6f", N, elapsed(&start, &end, NTIMES));
 
         FT_TIME(ft_execute_fourier2sphv(P, A, N, M), start, end, NTIMES)
-        printf("  %.6f\n", elapsed(&start, &end, NTIMES));
+        printf("  %.6f", elapsed(&start, &end, NTIMES));
 
+        printf("\n");
         free(A);
         ft_destroy_harmonic_plan(P);
     }
@@ -461,85 +525,107 @@ int main(int argc, const char * argv[]) {
         printf("ϵ_∞ default-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
         ft_checktest(err, 2*N, &checksum);
 
-        execute_tri_hi2lo_SSE2(RP, A, Ac, M);
-        execute_tri_lo2hi_default(RP, A, M);
+        #if defined(__i386__) || defined(__x86_64__)
+            execute_tri_hi2lo_SSE2(RP, A, Ac, M);
+            execute_tri_lo2hi_default(RP, A, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 SSE2-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 8*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ SSE2-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 SSE2-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 8*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ SSE2-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_tri_hi2lo_default(RP, A, M);
-        execute_tri_lo2hi_SSE2(RP, A, Ac, M);
+            execute_tri_hi2lo_default(RP, A, M);
+            execute_tri_lo2hi_SSE2(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 default-SSE2 \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 8*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ default-SSE2 \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 default-SSE2 \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 8*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ default-SSE2 \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_tri_hi2lo_AVX(RP, A, Ac, M);
-        execute_tri_lo2hi_SSE2(RP, A, Ac, M);
+            execute_tri_hi2lo_AVX(RP, A, Ac, M);
+            execute_tri_lo2hi_SSE2(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX-SSE2 \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 8*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX-SSE2 \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX-SSE2 \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 8*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX-SSE2 \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_tri_hi2lo_SSE2(RP, A, Ac, M);
-        execute_tri_lo2hi_AVX(RP, A, Ac, M);
+            execute_tri_hi2lo_SSE2(RP, A, Ac, M);
+            execute_tri_lo2hi_AVX(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 SSE2-AVX \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 8*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ SSE2-AVX \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 SSE2-AVX \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 8*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ SSE2-AVX \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_tri_hi2lo_AVX_FMA(RP, A, Ac, M);
-        execute_tri_lo2hi_AVX(RP, A, Ac, M);
+            execute_tri_hi2lo_AVX_FMA(RP, A, Ac, M);
+            execute_tri_lo2hi_AVX(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX_FMA-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 8*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX_FMA-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX_FMA-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 8*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX_FMA-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_tri_hi2lo_AVX(RP, A, Ac, M);
-        execute_tri_lo2hi_AVX_FMA(RP, A, Ac, M);
+            execute_tri_hi2lo_AVX(RP, A, Ac, M);
+            execute_tri_lo2hi_AVX_FMA(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 8*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 8*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_tri_hi2lo_AVX512F(RP, A, Ac, M);
-        execute_tri_lo2hi_AVX_FMA(RP, A, Ac, M);
+            execute_tri_hi2lo_AVX512F(RP, A, Ac, M);
+            execute_tri_lo2hi_AVX_FMA(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX512F-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 8*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX512F-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX512F-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 8*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX512F-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_tri_hi2lo_AVX_FMA(RP, A, Ac, M);
-        execute_tri_lo2hi_AVX512F(RP, A, Ac, M);
+            execute_tri_hi2lo_AVX_FMA(RP, A, Ac, M);
+            execute_tri_lo2hi_AVX512F(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX_FMA-AVX512F \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 8*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX_FMA-AVX512F \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX_FMA-AVX512F \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 8*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX_FMA-AVX512F \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
+        #elif defined(__aarch64__)
+            execute_tri_hi2lo_NEON(RP, A, Ac, M);
+            execute_tri_lo2hi_default(RP, A, M);
+
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 NEON-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 8*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ NEON-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
+
+            execute_tri_hi2lo_default(RP, A, M);
+            execute_tri_lo2hi_NEON(RP, A, Ac, M);
+
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 default-NEON \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 8*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ default-NEON \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
+        #endif
 
         free(A);
         free(Ac);
@@ -564,30 +650,39 @@ int main(int argc, const char * argv[]) {
         FT_TIME(execute_tri_lo2hi_default(RP, A, M), start, end, NTIMES)
         printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_tri_hi2lo_SSE2(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+        #if defined(__i386__) || defined(__x86_64__)
+            FT_TIME(execute_tri_hi2lo_SSE2(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_tri_lo2hi_SSE2(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_tri_lo2hi_SSE2(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_tri_hi2lo_AVX(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_tri_hi2lo_AVX(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_tri_lo2hi_AVX(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_tri_lo2hi_AVX(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_tri_hi2lo_AVX_FMA(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_tri_hi2lo_AVX_FMA(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_tri_lo2hi_AVX_FMA(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_tri_lo2hi_AVX_FMA(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_tri_hi2lo_AVX512F(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_tri_hi2lo_AVX512F(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_tri_lo2hi_AVX512F(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f\n", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_tri_lo2hi_AVX512F(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
+        #elif defined(__aarch64__)
+            FT_TIME(execute_tri_hi2lo_NEON(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
+            FT_TIME(execute_tri_lo2hi_NEON(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
+        #endif
+
+        printf("\n");
         free(A);
         free(B);
         ft_destroy_rotation_plan(RP);
@@ -634,8 +729,9 @@ int main(int argc, const char * argv[]) {
         printf("%d  %.6f", N, elapsed(&start, &end, NTIMES));
 
         FT_TIME(ft_execute_cheb2tri(P, A, N, M), start, end, NTIMES)
-        printf("  %.6f\n", elapsed(&start, &end, NTIMES));
+        printf("  %.6f", elapsed(&start, &end, NTIMES));
 
+        printf("\n");
         free(A);
         ft_destroy_harmonic_plan(P);
     }
@@ -663,85 +759,107 @@ int main(int argc, const char * argv[]) {
         printf("ϵ_∞ default-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
         ft_checktest(err, 2*N, &checksum);
 
-        execute_disk_hi2lo_SSE2(RP, A, Ac, M);
-        execute_disk_lo2hi_default(RP, A, M);
+        #if defined(__i386__) || defined(__x86_64__)
+            execute_disk_hi2lo_SSE2(RP, A, Ac, M);
+            execute_disk_lo2hi_default(RP, A, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 SSE2-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ SSE2-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 SSE2-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ SSE2-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_disk_hi2lo_default(RP, A, M);
-        execute_disk_lo2hi_SSE2(RP, A, Ac, M);
+            execute_disk_hi2lo_default(RP, A, M);
+            execute_disk_lo2hi_SSE2(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 default-SSE2 \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ default-SSE2 \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 default-SSE2 \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ default-SSE2 \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_disk_hi2lo_AVX(RP, A, Ac, M);
-        execute_disk_lo2hi_SSE2(RP, A, Ac, M);
+            execute_disk_hi2lo_AVX(RP, A, Ac, M);
+            execute_disk_lo2hi_SSE2(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX-SSE2 \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX-SSE2 \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX-SSE2 \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX-SSE2 \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_disk_hi2lo_SSE2(RP, A, Ac, M);
-        execute_disk_lo2hi_AVX(RP, A, Ac, M);
+            execute_disk_hi2lo_SSE2(RP, A, Ac, M);
+            execute_disk_lo2hi_AVX(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 SSE2-AVX \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ SSE2-AVX \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 SSE2-AVX \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ SSE2-AVX \t\t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_disk_hi2lo_AVX_FMA(RP, A, Ac, M);
-        execute_disk_lo2hi_AVX(RP, A, Ac, M);
+            execute_disk_hi2lo_AVX_FMA(RP, A, Ac, M);
+            execute_disk_lo2hi_AVX(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX_FMA-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX_FMA-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX_FMA-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX_FMA-AVX \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_disk_hi2lo_AVX(RP, A, Ac, M);
-        execute_disk_lo2hi_AVX_FMA(RP, A, Ac, M);
+            execute_disk_hi2lo_AVX(RP, A, Ac, M);
+            execute_disk_lo2hi_AVX_FMA(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_disk_hi2lo_AVX512F(RP, A, Ac, M);
-        execute_disk_lo2hi_AVX_FMA(RP, A, Ac, M);
+            execute_disk_hi2lo_AVX512F(RP, A, Ac, M);
+            execute_disk_lo2hi_AVX_FMA(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX512F-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX512F-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX512F-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX512F-AVX_FMA \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
 
-        execute_disk_hi2lo_AVX_FMA(RP, A, Ac, M);
-        execute_disk_lo2hi_AVX512F(RP, A, Ac, M);
+            execute_disk_hi2lo_AVX_FMA(RP, A, Ac, M);
+            execute_disk_lo2hi_AVX512F(RP, A, Ac, M);
 
-        err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
-        printf("ϵ_2 AVX_FMA-AVX512F \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 4*sqrt(N), &checksum);
-        err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
-        printf("ϵ_∞ AVX_FMA-AVX512F \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
-        ft_checktest(err, 2*N, &checksum);
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 AVX_FMA-AVX512F \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ AVX_FMA-AVX512F \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
+        #elif defined(__aarch64__)
+            execute_disk_hi2lo_NEON(RP, A, Ac, M);
+            execute_disk_lo2hi_default(RP, A, M);
+
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 NEON-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ NEON-default \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
+
+            execute_disk_hi2lo_default(RP, A, M);
+            execute_disk_lo2hi_NEON(RP, A, Ac, M);
+
+            err = ft_norm_2arg(A, B, N*M)/ft_norm_1arg(B, N*M);
+            printf("ϵ_2 default-NEON \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 4*sqrt(N), &checksum);
+            err = ft_normInf_2arg(A, B, N*M)/ft_normInf_1arg(B, N*M);
+            printf("ϵ_∞ default-NEON \t (N×M) = (%5ix%5i): \t |%20.2e ", N, M, err);
+            ft_checktest(err, 2*N, &checksum);
+        #endif
 
         free(A);
         VFREE(Ac);
@@ -766,30 +884,39 @@ int main(int argc, const char * argv[]) {
         FT_TIME(execute_disk_lo2hi_default(RP, A, M), start, end, NTIMES)
         printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_disk_hi2lo_SSE2(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+        #if defined(__i386__) || defined(__x86_64__)
+            FT_TIME(execute_disk_hi2lo_SSE2(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_disk_lo2hi_SSE2(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_disk_lo2hi_SSE2(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_disk_hi2lo_AVX(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_disk_hi2lo_AVX(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_disk_lo2hi_AVX(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_disk_lo2hi_AVX(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_disk_hi2lo_AVX_FMA(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_disk_hi2lo_AVX_FMA(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_disk_lo2hi_AVX_FMA(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_disk_lo2hi_AVX_FMA(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_disk_hi2lo_AVX512F(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_disk_hi2lo_AVX512F(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-        FT_TIME(execute_disk_lo2hi_AVX512F(RP, A, B, M), start, end, NTIMES)
-        printf("  %.6f\n", elapsed(&start, &end, NTIMES));
+            FT_TIME(execute_disk_lo2hi_AVX512F(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
+        #elif defined(__aarch64__)
+            FT_TIME(execute_disk_hi2lo_NEON(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
 
+            FT_TIME(execute_disk_lo2hi_NEON(RP, A, B, M), start, end, NTIMES)
+            printf("  %.6f", elapsed(&start, &end, NTIMES));
+        #endif
+
+        printf("\n");
         free(A);
         VFREE(B);
         ft_destroy_rotation_plan(RP);
@@ -836,8 +963,9 @@ int main(int argc, const char * argv[]) {
         printf("%d  %.6f", N, elapsed(&start, &end, NTIMES));
 
         FT_TIME(ft_execute_cxf2disk(P, A, N, M), start, end, NTIMES)
-        printf("  %.6f\n", elapsed(&start, &end, NTIMES));
+        printf("  %.6f", elapsed(&start, &end, NTIMES));
 
+        printf("\n");
         free(A);
         ft_destroy_harmonic_plan(P);
     }
@@ -969,8 +1097,9 @@ int main(int argc, const char * argv[]) {
         printf("  %.6f", elapsed(&start, &end, NTIMES));
 
         FT_TIME(execute_tet_lo2hi_AVX512F(RP1, RP2, A, B, L, M), start, end, NTIMES)
-        printf("  %.6f\n", elapsed(&start, &end, NTIMES));
+        printf("  %.6f", elapsed(&start, &end, NTIMES));
 
+        printf("\n");
         free(A);
         VFREE(B);
         ft_destroy_rotation_plan(RP1);
@@ -1018,8 +1147,9 @@ int main(int argc, const char * argv[]) {
         printf("%d  %.6f", N, elapsed(&start, &end, NTIMES));
 
         FT_TIME(ft_execute_cheb2tet(TP, A, N, L, M), start, end, NTIMES)
-        printf("  %.6f\n", elapsed(&start, &end, NTIMES));
+        printf("  %.6f", elapsed(&start, &end, NTIMES));
 
+        printf("\n");
         free(A);
         ft_destroy_tetrahedral_harmonic_plan(TP);
     }
@@ -1051,65 +1181,87 @@ int main(int argc, const char * argv[]) {
             printf("ϵ_∞ default-default \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
             ft_checktest(err, 2*N, &checksum);
 
-            execute_spinsph_hi2lo_SSE2(SRP, AC, M);
-            execute_spinsph_lo2hi_default(SRP, AC, M);
+            #if defined(__i386__) || defined(__x86_64__)
+                execute_spinsph_hi2lo_SSE2(SRP, AC, M);
+                execute_spinsph_lo2hi_default(SRP, AC, M);
 
-            err = ft_norm_2arg(A, B, 2*N*M)/ft_norm_1arg(B, 2*N*M);
-            printf("ϵ_2 SSE2-default \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
-            ft_checktest(err, 4*sqrt(N), &checksum);
-            err = ft_normInf_2arg(A, B, 2*N*M)/ft_normInf_1arg(B, 2*N*M);
-            printf("ϵ_∞ SSE2-default \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
-            ft_checktest(err, 2*N, &checksum);
+                err = ft_norm_2arg(A, B, 2*N*M)/ft_norm_1arg(B, 2*N*M);
+                printf("ϵ_2 SSE2-default \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
+                ft_checktest(err, 4*sqrt(N), &checksum);
+                err = ft_normInf_2arg(A, B, 2*N*M)/ft_normInf_1arg(B, 2*N*M);
+                printf("ϵ_∞ SSE2-default \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
+                ft_checktest(err, 2*N, &checksum);
 
-            execute_spinsph_hi2lo_default(SRP, AC, M);
-            execute_spinsph_lo2hi_SSE2(SRP, AC, M);
+                execute_spinsph_hi2lo_default(SRP, AC, M);
+                execute_spinsph_lo2hi_SSE2(SRP, AC, M);
 
-            err = ft_norm_2arg(A, B, 2*N*M)/ft_norm_1arg(B, 2*N*M);
-            printf("ϵ_2 default-SSE2 \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
-            ft_checktest(err, 4*sqrt(N), &checksum);
-            err = ft_normInf_2arg(A, B, 2*N*M)/ft_normInf_1arg(B, 2*N*M);
-            printf("ϵ_∞ default-SSE2 \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
-            ft_checktest(err, 2*N, &checksum);
+                err = ft_norm_2arg(A, B, 2*N*M)/ft_norm_1arg(B, 2*N*M);
+                printf("ϵ_2 default-SSE2 \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
+                ft_checktest(err, 4*sqrt(N), &checksum);
+                err = ft_normInf_2arg(A, B, 2*N*M)/ft_normInf_1arg(B, 2*N*M);
+                printf("ϵ_∞ default-SSE2 \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
+                ft_checktest(err, 2*N, &checksum);
 
-            execute_spinsph_hi2lo_AVX(SRP, AC, AcC, M);
-            execute_spinsph_lo2hi_SSE2(SRP, AC, M);
+                execute_spinsph_hi2lo_AVX(SRP, AC, AcC, M);
+                execute_spinsph_lo2hi_SSE2(SRP, AC, M);
 
-            err = ft_norm_2arg(A, B, 2*N*M)/ft_norm_1arg(B, 2*N*M);
-            printf("ϵ_2 AVX-SSE2 \t\t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
-            ft_checktest(err, 4*sqrt(N), &checksum);
-            err = ft_normInf_2arg(A, B, 2*N*M)/ft_normInf_1arg(B, 2*N*M);
-            printf("ϵ_∞ AVX-SSE2 \t\t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
-            ft_checktest(err, 2*N, &checksum);
+                err = ft_norm_2arg(A, B, 2*N*M)/ft_norm_1arg(B, 2*N*M);
+                printf("ϵ_2 AVX-SSE2 \t\t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
+                ft_checktest(err, 4*sqrt(N), &checksum);
+                err = ft_normInf_2arg(A, B, 2*N*M)/ft_normInf_1arg(B, 2*N*M);
+                printf("ϵ_∞ AVX-SSE2 \t\t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
+                ft_checktest(err, 2*N, &checksum);
 
-            execute_spinsph_hi2lo_SSE2(SRP, AC, M);
-            execute_spinsph_lo2hi_AVX(SRP, AC, AcC, M);
+                execute_spinsph_hi2lo_SSE2(SRP, AC, M);
+                execute_spinsph_lo2hi_AVX(SRP, AC, AcC, M);
 
-            err = ft_norm_2arg(A, B, 2*N*M)/ft_norm_1arg(B, 2*N*M);
-            printf("ϵ_2 SSE2-AVX \t\t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
-            ft_checktest(err, 4*sqrt(N), &checksum);
-            err = ft_normInf_2arg(A, B, 2*N*M)/ft_normInf_1arg(B, 2*N*M);
-            printf("ϵ_∞ SSE2-AVX \t\t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
-            ft_checktest(err, 2*N, &checksum);
+                err = ft_norm_2arg(A, B, 2*N*M)/ft_norm_1arg(B, 2*N*M);
+                printf("ϵ_2 SSE2-AVX \t\t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
+                ft_checktest(err, 4*sqrt(N), &checksum);
+                err = ft_normInf_2arg(A, B, 2*N*M)/ft_normInf_1arg(B, 2*N*M);
+                printf("ϵ_∞ SSE2-AVX \t\t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
+                ft_checktest(err, 2*N, &checksum);
 
-            execute_spinsph_hi2lo_AVX_FMA(SRP, AC, AcC, M);
-            execute_spinsph_lo2hi_AVX(SRP, AC, AcC, M);
+                execute_spinsph_hi2lo_AVX_FMA(SRP, AC, AcC, M);
+                execute_spinsph_lo2hi_AVX(SRP, AC, AcC, M);
 
-            err = ft_norm_2arg(A, B, 2*N*M)/ft_norm_1arg(B, 2*N*M);
-            printf("ϵ_2 AVX_FMA-AVX \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
-            ft_checktest(err, 4*sqrt(N), &checksum);
-            err = ft_normInf_2arg(A, B, 2*N*M)/ft_normInf_1arg(B, 2*N*M);
-            printf("ϵ_∞ AVX_FMA-AVX \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
-            ft_checktest(err, 2*N, &checksum);
+                err = ft_norm_2arg(A, B, 2*N*M)/ft_norm_1arg(B, 2*N*M);
+                printf("ϵ_2 AVX_FMA-AVX \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
+                ft_checktest(err, 4*sqrt(N), &checksum);
+                err = ft_normInf_2arg(A, B, 2*N*M)/ft_normInf_1arg(B, 2*N*M);
+                printf("ϵ_∞ AVX_FMA-AVX \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
+                ft_checktest(err, 2*N, &checksum);
 
-            execute_spinsph_hi2lo_AVX(SRP, AC, AcC, M);
-            execute_spinsph_lo2hi_AVX_FMA(SRP, AC, AcC, M);
+                execute_spinsph_hi2lo_AVX(SRP, AC, AcC, M);
+                execute_spinsph_lo2hi_AVX_FMA(SRP, AC, AcC, M);
 
-            err = ft_norm_2arg(A, B, 2*N*M)/ft_norm_1arg(B, 2*N*M);
-            printf("ϵ_2 AVX-AVX_FMA \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
-            ft_checktest(err, 4*sqrt(N), &checksum);
-            err = ft_normInf_2arg(A, B, 2*N*M)/ft_normInf_1arg(B, 2*N*M);
-            printf("ϵ_∞ AVX-AVX_FMA \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
-            ft_checktest(err, 2*N, &checksum);
+                err = ft_norm_2arg(A, B, 2*N*M)/ft_norm_1arg(B, 2*N*M);
+                printf("ϵ_2 AVX-AVX_FMA \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
+                ft_checktest(err, 4*sqrt(N), &checksum);
+                err = ft_normInf_2arg(A, B, 2*N*M)/ft_normInf_1arg(B, 2*N*M);
+                printf("ϵ_∞ AVX-AVX_FMA \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
+                ft_checktest(err, 2*N, &checksum);
+            #elif defined(__aarch64__)
+                execute_spinsph_hi2lo_NEON(SRP, AC, M);
+                execute_spinsph_lo2hi_default(SRP, AC, M);
+
+                err = ft_norm_2arg(A, B, 2*N*M)/ft_norm_1arg(B, 2*N*M);
+                printf("ϵ_2 NEON-default \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
+                ft_checktest(err, 4*sqrt(N), &checksum);
+                err = ft_normInf_2arg(A, B, 2*N*M)/ft_normInf_1arg(B, 2*N*M);
+                printf("ϵ_∞ NEON-default \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
+                ft_checktest(err, 2*N, &checksum);
+
+                execute_spinsph_hi2lo_default(SRP, AC, M);
+                execute_spinsph_lo2hi_NEON(SRP, AC, M);
+
+                err = ft_norm_2arg(A, B, 2*N*M)/ft_norm_1arg(B, 2*N*M);
+                printf("ϵ_2 default-NEON \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
+                ft_checktest(err, 4*sqrt(N), &checksum);
+                err = ft_normInf_2arg(A, B, 2*N*M)/ft_normInf_1arg(B, 2*N*M);
+                printf("ϵ_∞ default-NEON \t (N×M, S) = (%5ix%5i,%3i): \t |%20.2e ", N, M, S, err);
+                ft_checktest(err, 2*N, &checksum);
+            #endif
 
             free(AC);
             VFREE(AcC);
@@ -1138,23 +1290,31 @@ int main(int argc, const char * argv[]) {
             FT_TIME(execute_spinsph_lo2hi_default(SRP, AC, M), start, end, NTIMES)
             printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-            FT_TIME(execute_spinsph_hi2lo_SSE2(SRP, AC, M), start, end, NTIMES)
-            printf("  %.6f", elapsed(&start, &end, NTIMES));
+            #if defined(__i386__) || defined(__x86_64__)
+                FT_TIME(execute_spinsph_hi2lo_SSE2(SRP, AC, M), start, end, NTIMES)
+                printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-            FT_TIME(execute_spinsph_lo2hi_SSE2(SRP, AC, M), start, end, NTIMES)
-            printf("  %.6f", elapsed(&start, &end, NTIMES));
+                FT_TIME(execute_spinsph_lo2hi_SSE2(SRP, AC, M), start, end, NTIMES)
+                printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-            FT_TIME(execute_spinsph_hi2lo_AVX(SRP, AC, BC, M), start, end, NTIMES)
-            printf("  %.6f", elapsed(&start, &end, NTIMES));
+                FT_TIME(execute_spinsph_hi2lo_AVX(SRP, AC, BC, M), start, end, NTIMES)
+                printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-            FT_TIME(execute_spinsph_lo2hi_AVX(SRP, AC, BC, M), start, end, NTIMES)
-            printf("  %.6f", elapsed(&start, &end, NTIMES));
+                FT_TIME(execute_spinsph_lo2hi_AVX(SRP, AC, BC, M), start, end, NTIMES)
+                printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-            FT_TIME(execute_spinsph_hi2lo_AVX_FMA(SRP, AC, BC, M), start, end, NTIMES)
-            printf("  %.6f", elapsed(&start, &end, NTIMES));
+                FT_TIME(execute_spinsph_hi2lo_AVX_FMA(SRP, AC, BC, M), start, end, NTIMES)
+                printf("  %.6f", elapsed(&start, &end, NTIMES));
 
-            FT_TIME(execute_spinsph_lo2hi_AVX_FMA(SRP, AC, BC, M), start, end, NTIMES)
-            printf("  %.6f\n", elapsed(&start, &end, NTIMES));
+                FT_TIME(execute_spinsph_lo2hi_AVX_FMA(SRP, AC, BC, M), start, end, NTIMES)
+                printf("  %.6f", elapsed(&start, &end, NTIMES));
+            #elif defined(__aarch64__)
+                FT_TIME(execute_spinsph_hi2lo_NEON(SRP, AC, M), start, end, NTIMES)
+                printf("  %.6f", elapsed(&start, &end, NTIMES));
+
+                FT_TIME(execute_spinsph_lo2hi_NEON(SRP, AC, M), start, end, NTIMES)
+                printf("  %.6f", elapsed(&start, &end, NTIMES));
+            #endif
 
             free(AC);
             free(BC);

--- a/test/test_drivers.c
+++ b/test/test_drivers.c
@@ -1316,6 +1316,7 @@ int main(int argc, const char * argv[]) {
                 printf("  %.6f", elapsed(&start, &end, NTIMES));
             #endif
 
+            printf("\n");
             free(AC);
             free(BC);
             ft_destroy_spin_rotation_plan(SRP);

--- a/test/test_recurrence.c
+++ b/test/test_recurrence.c
@@ -15,6 +15,7 @@ int main(void) {
     simd.avx2 ? printf("AVX2 detected.\t\t\t\t\t\t\t\t       "GREEN("✓")"\n") : printf("AVX2 not detected.\t\t\t\t\t\t\t       "RED("✗")"\n");
     simd.fma ? printf("FMA detected.\t\t\t\t\t\t\t\t       "GREEN("✓")"\n") : printf("FMA not detected.\t\t\t\t\t\t\t       "RED("✗")"\n");
     simd.avx512f ? printf("AVX512F detected.\t\t\t\t\t\t\t       "GREEN("✓")"\n") : printf("AVX512F not detected.\t\t\t\t\t\t\t       "RED("✗")"\n");
+    simd.neon ? printf("NEON detected.\t\t\t\t\t\t\t\t       "GREEN("✓")"\n") : printf("NEON not detected.\t\t\t\t\t\t\t       "RED("✗")"\n");
     printf("The "CYAN("sizeof(ft_simd)")" is \t\t\t\t\t\t\t       %li\n", sizeof(ft_simd));
 
     printf("\nTesting methods for Horner summation.\n");
@@ -42,6 +43,8 @@ int main(void) {
             horner_AVX_FMAf(n, c, 1, m, x, f);
             err += powf(ft_norm_2argf(f, fd, m), 2);
             horner_AVX512Ff(n, c, 1, m, x, f);
+            err += powf(ft_norm_2argf(f, fd, m), 2);
+            horner_NEONf(n, c, 1, m, x, f);
             err += powf(ft_norm_2argf(f, fd, m), 2);
             ft_hornerf(n, c, 1, m, x, f);
             err += powf(ft_norm_2argf(f, fd, m), 2);
@@ -84,6 +87,9 @@ int main(void) {
             FT_TIME(horner_AVX512Ff(n, c, 1, m, x, f), start, end, NTIMES)
             printf("Time for horner_AVX512Ff \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
+            FT_TIME(horner_NEONf(n, c, 1, m, x, f), start, end, NTIMES)
+            printf("Time for horner_NEONf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+
             FT_TIME(ft_hornerf(n, c, 1, m, x, f), start, end, NTIMES)
             printf("Time for ft_hornerf \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
@@ -117,6 +123,8 @@ int main(void) {
             horner_AVX_FMA(n, c, 1, m, x, f);
             err += pow(ft_norm_2arg(f, fd, m), 2);
             horner_AVX512F(n, c, 1, m, x, f);
+            err += pow(ft_norm_2arg(f, fd, m), 2);
+            horner_NEON(n, c, 1, m, x, f);
             err += pow(ft_norm_2arg(f, fd, m), 2);
             ft_horner(n, c, 1, m, x, f);
             err += pow(ft_norm_2arg(f, fd, m), 2);
@@ -159,6 +167,9 @@ int main(void) {
             FT_TIME(horner_AVX512F(n, c, 1, m, x, f), start, end, NTIMES)
             printf("Time for horner_AVX512F \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
+            FT_TIME(horner_NEON(n, c, 1, m, x, f), start, end, NTIMES)
+            printf("Time for horner_NEON \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+
             FT_TIME(ft_horner(n, c, 1, m, x, f), start, end, NTIMES)
             printf("Time for ft_horner \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
@@ -193,6 +204,8 @@ int main(void) {
             clenshaw_AVX_FMAf(n, c, 1, m, x, f);
             err += powf(ft_norm_2argf(f, fd, m), 2);
             clenshaw_AVX512Ff(n, c, 1, m, x, f);
+            err += powf(ft_norm_2argf(f, fd, m), 2);
+            clenshaw_NEONf(n, c, 1, m, x, f);
             err += powf(ft_norm_2argf(f, fd, m), 2);
             ft_clenshawf(n, c, 1, m, x, f);
             err += powf(ft_norm_2argf(f, fd, m), 2);
@@ -235,6 +248,9 @@ int main(void) {
             FT_TIME(clenshaw_AVX512Ff(n, c, 1, m, x, f), start, end, NTIMES)
             printf("Time for clenshaw_AVX512Ff \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
+            FT_TIME(clenshaw_NEONf(n, c, 1, m, x, f), start, end, NTIMES)
+            printf("Time for clenshaw_NEONf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+
             FT_TIME(ft_clenshawf(n, c, 1, m, x, f), start, end, NTIMES)
             printf("Time for ft_clenshawf \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
@@ -268,6 +284,8 @@ int main(void) {
             clenshaw_AVX_FMA(n, c, 1, m, x, f);
             err += pow(ft_norm_2arg(f, fd, m), 2);
             clenshaw_AVX512F(n, c, 1, m, x, f);
+            err += pow(ft_norm_2arg(f, fd, m), 2);
+            clenshaw_NEON(n, c, 1, m, x, f);
             err += pow(ft_norm_2arg(f, fd, m), 2);
             ft_clenshaw(n, c, 1, m, x, f);
             err += pow(ft_norm_2arg(f, fd, m), 2);
@@ -309,6 +327,9 @@ int main(void) {
 
             FT_TIME(clenshaw_AVX512F(n, c, 1, m, x, f), start, end, NTIMES)
             printf("Time for clenshaw_AVX512F \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+
+            FT_TIME(clenshaw_NEON(n, c, 1, m, x, f), start, end, NTIMES)
+            printf("Time for clenshaw_NEON \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
             FT_TIME(ft_clenshaw(n, c, 1, m, x, f), start, end, NTIMES)
             printf("Time for ft_clenshaw \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
@@ -355,6 +376,8 @@ int main(void) {
             orthogonal_polynomial_clenshaw_AVX_FMAf(n, c, 1, A, B, C, m, x, phi0, f);
             err += powf(ft_norm_2argf(f, fd, m), 2);
             orthogonal_polynomial_clenshaw_AVX512Ff(n, c, 1, A, B, C, m, x, phi0, f);
+            err += powf(ft_norm_2argf(f, fd, m), 2);
+            orthogonal_polynomial_clenshaw_NEONf(n, c, 1, A, B, C, m, x, phi0, f);
             err += powf(ft_norm_2argf(f, fd, m), 2);
             ft_orthogonal_polynomial_clenshawf(n, c, 1, A, B, C, m, x, phi0, f);
             err += powf(ft_norm_2argf(f, fd, m), 2);
@@ -413,6 +436,9 @@ int main(void) {
             FT_TIME(orthogonal_polynomial_clenshaw_AVX512Ff(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
             printf("Time for OP clenshaw_AVX512Ff \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
+            FT_TIME(orthogonal_polynomial_clenshaw_NEONf(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
+            printf("Time for OP clenshaw_NEONf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+
             FT_TIME(ft_orthogonal_polynomial_clenshawf(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
             printf("Time for OP ft_clenshawf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
@@ -461,6 +487,8 @@ int main(void) {
             orthogonal_polynomial_clenshaw_AVX_FMA(n, c, 1, A, B, C, m, x, phi0, f);
             err += pow(ft_norm_2arg(f, fd, m), 2);
             orthogonal_polynomial_clenshaw_AVX512F(n, c, 1, A, B, C, m, x, phi0, f);
+            err += pow(ft_norm_2arg(f, fd, m), 2);
+            orthogonal_polynomial_clenshaw_NEON(n, c, 1, A, B, C, m, x, phi0, f);
             err += pow(ft_norm_2arg(f, fd, m), 2);
             ft_orthogonal_polynomial_clenshaw(n, c, 1, A, B, C, m, x, phi0, f);
             err += pow(ft_norm_2arg(f, fd, m), 2);
@@ -518,6 +546,9 @@ int main(void) {
 
             FT_TIME(orthogonal_polynomial_clenshaw_AVX512F(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
             printf("Time for OP clenshaw_AVX512F \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+
+            FT_TIME(orthogonal_polynomial_clenshaw_NEON(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
+            printf("Time for OP clenshaw_NEON \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
             FT_TIME(ft_orthogonal_polynomial_clenshaw(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
             printf("Time for OP ft_clenshaw \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));

--- a/test/test_recurrence.c
+++ b/test/test_recurrence.c
@@ -45,8 +45,7 @@ int main(void) {
                 err += powf(ft_norm_2argf(f, fd, m), 2);
                 horner_AVX512Ff(n, c, 1, m, x, f);
                 err += powf(ft_norm_2argf(f, fd, m), 2);
-            #endif
-            #if defined(__aarch64__)
+            #elif defined(__aarch64__)
                 horner_NEONf(n, c, 1, m, x, f);
                 err += powf(ft_norm_2argf(f, fd, m), 2);
             #endif
@@ -91,9 +90,7 @@ int main(void) {
 
                 FT_TIME(horner_AVX512Ff(n, c, 1, m, x, f), start, end, NTIMES)
                 printf("Time for horner_AVX512Ff \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
-            #endif
-
-            #if defined(__aarch64__)
+            #elif defined(__aarch64__)
                 FT_TIME(horner_NEONf(n, c, 1, m, x, f), start, end, NTIMES)
                 printf("Time for horner_NEONf \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
             #endif
@@ -133,8 +130,7 @@ int main(void) {
                 err += pow(ft_norm_2arg(f, fd, m), 2);
                 horner_AVX512F(n, c, 1, m, x, f);
                 err += pow(ft_norm_2arg(f, fd, m), 2);
-            #endif
-            #if defined(__aarch64__)
+            #elif defined(__aarch64__)
                 horner_NEON(n, c, 1, m, x, f);
                 err += pow(ft_norm_2arg(f, fd, m), 2);
             #endif
@@ -179,9 +175,7 @@ int main(void) {
 
                 FT_TIME(horner_AVX512F(n, c, 1, m, x, f), start, end, NTIMES)
                 printf("Time for horner_AVX512F \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
-            #endif
-
-            #if defined(__aarch64__)
+            #elif defined(__aarch64__)
                 FT_TIME(horner_NEON(n, c, 1, m, x, f), start, end, NTIMES)
                 printf("Time for horner_NEON \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
             #endif
@@ -222,8 +216,7 @@ int main(void) {
                 err += powf(ft_norm_2argf(f, fd, m), 2);
                 clenshaw_AVX512Ff(n, c, 1, m, x, f);
                 err += powf(ft_norm_2argf(f, fd, m), 2);
-            #endif
-            #if defined(__aarch64__)
+            #elif defined(__aarch64__)
                 clenshaw_NEONf(n, c, 1, m, x, f);
                 err += powf(ft_norm_2argf(f, fd, m), 2);
             #endif
@@ -268,9 +261,7 @@ int main(void) {
 
                 FT_TIME(clenshaw_AVX512Ff(n, c, 1, m, x, f), start, end, NTIMES)
                 printf("Time for clenshaw_AVX512Ff \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
-            #endif
-
-            #if defined(__aarch64__)
+            #elif defined(__aarch64__)
                 FT_TIME(clenshaw_NEONf(n, c, 1, m, x, f), start, end, NTIMES)
                 printf("Time for clenshaw_NEONf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
             #endif
@@ -310,8 +301,7 @@ int main(void) {
                 err += pow(ft_norm_2arg(f, fd, m), 2);
                 clenshaw_AVX512F(n, c, 1, m, x, f);
                 err += pow(ft_norm_2arg(f, fd, m), 2);
-            #endif
-            #if defined(__aarch64__)
+            #elif defined(__aarch64__)
                 clenshaw_NEON(n, c, 1, m, x, f);
                 err += pow(ft_norm_2arg(f, fd, m), 2);
             #endif
@@ -356,9 +346,7 @@ int main(void) {
 
                 FT_TIME(clenshaw_AVX512F(n, c, 1, m, x, f), start, end, NTIMES)
                 printf("Time for clenshaw_AVX512F \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
-            #endif
-
-            #if defined(__aarch64__)
+            #elif defined(__aarch64__)
                 FT_TIME(clenshaw_NEON(n, c, 1, m, x, f), start, end, NTIMES)
                 printf("Time for clenshaw_NEON \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
             #endif
@@ -410,8 +398,7 @@ int main(void) {
                 err += powf(ft_norm_2argf(f, fd, m), 2);
                 orthogonal_polynomial_clenshaw_AVX512Ff(n, c, 1, A, B, C, m, x, phi0, f);
                 err += powf(ft_norm_2argf(f, fd, m), 2);
-            #endif
-            #if defined(__aarch64__)
+            #elif defined(__aarch64__)
                 orthogonal_polynomial_clenshaw_NEONf(n, c, 1, A, B, C, m, x, phi0, f);
                 err += powf(ft_norm_2argf(f, fd, m), 2);
             #endif
@@ -472,9 +459,7 @@ int main(void) {
 
                 FT_TIME(orthogonal_polynomial_clenshaw_AVX512Ff(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
                 printf("Time for OP clenshaw_AVX512Ff \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
-            #endif
-
-            #if defined(__aarch64__)
+            #elif defined(__aarch64__)
                 FT_TIME(orthogonal_polynomial_clenshaw_NEONf(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
                 printf("Time for OP clenshaw_NEONf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
             #endif
@@ -529,8 +514,7 @@ int main(void) {
                 err += pow(ft_norm_2arg(f, fd, m), 2);
                 orthogonal_polynomial_clenshaw_AVX512F(n, c, 1, A, B, C, m, x, phi0, f);
                 err += pow(ft_norm_2arg(f, fd, m), 2);
-            #endif
-            #if defined(__aarch64__)
+            #elif defined(__aarch64__)
                 orthogonal_polynomial_clenshaw_NEON(n, c, 1, A, B, C, m, x, phi0, f);
                 err += pow(ft_norm_2arg(f, fd, m), 2);
             #endif
@@ -591,9 +575,7 @@ int main(void) {
 
                 FT_TIME(orthogonal_polynomial_clenshaw_AVX512F(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
                 printf("Time for OP clenshaw_AVX512F \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
-            #endif
-
-            #if defined(__aarch64__)
+            #elif defined(__aarch64__)
                 FT_TIME(orthogonal_polynomial_clenshaw_NEON(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
                 printf("Time for OP clenshaw_NEON \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
             #endif

--- a/test/test_recurrence.c
+++ b/test/test_recurrence.c
@@ -88,7 +88,7 @@ int main(void) {
             printf("Time for horner_AVX512Ff \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
             FT_TIME(horner_NEONf(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for horner_NEONf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            printf("Time for horner_NEONf \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
             FT_TIME(ft_hornerf(n, c, 1, m, x, f), start, end, NTIMES)
             printf("Time for ft_hornerf \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
@@ -168,7 +168,7 @@ int main(void) {
             printf("Time for horner_AVX512F \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
             FT_TIME(horner_NEON(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for horner_NEON \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            printf("Time for horner_NEON \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
             FT_TIME(ft_horner(n, c, 1, m, x, f), start, end, NTIMES)
             printf("Time for ft_horner \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
@@ -329,7 +329,7 @@ int main(void) {
             printf("Time for clenshaw_AVX512F \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
             FT_TIME(clenshaw_NEON(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for clenshaw_NEON \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            printf("Time for clenshaw_NEON \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
             FT_TIME(ft_clenshaw(n, c, 1, m, x, f), start, end, NTIMES)
             printf("Time for ft_clenshaw \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));

--- a/test/test_recurrence.c
+++ b/test/test_recurrence.c
@@ -36,16 +36,20 @@ int main(void) {
                 x[j] = (-1.0f+2.0f*j/(m-1.0f));
 
             horner_defaultf(n, c, 1, m, x, fd);
-            horner_SSEf(n, c, 1, m, x, f);
-            err = powf(ft_norm_2argf(f, fd, m), 2);
-            horner_AVXf(n, c, 1, m, x, f);
-            err += powf(ft_norm_2argf(f, fd, m), 2);
-            horner_AVX_FMAf(n, c, 1, m, x, f);
-            err += powf(ft_norm_2argf(f, fd, m), 2);
-            horner_AVX512Ff(n, c, 1, m, x, f);
-            err += powf(ft_norm_2argf(f, fd, m), 2);
-            horner_NEONf(n, c, 1, m, x, f);
-            err += powf(ft_norm_2argf(f, fd, m), 2);
+            #if defined(__i386__) || defined(__x86_64__)
+                horner_SSEf(n, c, 1, m, x, f);
+                err += powf(ft_norm_2argf(f, fd, m), 2);
+                horner_AVXf(n, c, 1, m, x, f);
+                err += powf(ft_norm_2argf(f, fd, m), 2);
+                horner_AVX_FMAf(n, c, 1, m, x, f);
+                err += powf(ft_norm_2argf(f, fd, m), 2);
+                horner_AVX512Ff(n, c, 1, m, x, f);
+                err += powf(ft_norm_2argf(f, fd, m), 2);
+            #endif
+            #if defined(__aarch64__)
+                horner_NEONf(n, c, 1, m, x, f);
+                err += powf(ft_norm_2argf(f, fd, m), 2);
+            #endif
             ft_hornerf(n, c, 1, m, x, f);
             err += powf(ft_norm_2argf(f, fd, m), 2);
             err = sqrtf(err);
@@ -75,20 +79,24 @@ int main(void) {
             //for (int i = 0; i < n; i++)
             //    printf("c[%i] = %3.5f, x[%i] = %3.5f, f[%i] = %3.8f\n", i, c[i], i, x[i], i, f[i]);
 
-            FT_TIME(horner_SSEf(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for horner_SSEf \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #if defined(__i386__) || defined(__x86_64__)
+                FT_TIME(horner_SSEf(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for horner_SSEf \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(horner_AVXf(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for horner_AVXf \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(horner_AVXf(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for horner_AVXf \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(horner_AVX_FMAf(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for horner_AVX_FMAf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(horner_AVX_FMAf(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for horner_AVX_FMAf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(horner_AVX512Ff(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for horner_AVX512Ff \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(horner_AVX512Ff(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for horner_AVX512Ff \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #endif
 
-            FT_TIME(horner_NEONf(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for horner_NEONf \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #if defined(__aarch64__)
+                FT_TIME(horner_NEONf(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for horner_NEONf \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #endif
 
             FT_TIME(ft_hornerf(n, c, 1, m, x, f), start, end, NTIMES)
             printf("Time for ft_hornerf \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
@@ -116,16 +124,20 @@ int main(void) {
                 x[j] = (-1.0+2.0*j/(m-1.0));
 
             horner_default(n, c, 1, m, x, fd);
-            horner_SSE2(n, c, 1, m, x, f);
-            err = pow(ft_norm_2arg(f, fd, m), 2);
-            horner_AVX(n, c, 1, m, x, f);
-            err += pow(ft_norm_2arg(f, fd, m), 2);
-            horner_AVX_FMA(n, c, 1, m, x, f);
-            err += pow(ft_norm_2arg(f, fd, m), 2);
-            horner_AVX512F(n, c, 1, m, x, f);
-            err += pow(ft_norm_2arg(f, fd, m), 2);
-            horner_NEON(n, c, 1, m, x, f);
-            err += pow(ft_norm_2arg(f, fd, m), 2);
+            #if defined(__i386__) || defined(__x86_64__)
+                horner_SSE2(n, c, 1, m, x, f);
+                err += pow(ft_norm_2arg(f, fd, m), 2);
+                horner_AVX(n, c, 1, m, x, f);
+                err += pow(ft_norm_2arg(f, fd, m), 2);
+                horner_AVX_FMA(n, c, 1, m, x, f);
+                err += pow(ft_norm_2arg(f, fd, m), 2);
+                horner_AVX512F(n, c, 1, m, x, f);
+                err += pow(ft_norm_2arg(f, fd, m), 2);
+            #endif
+            #if defined(__aarch64__)
+                horner_NEON(n, c, 1, m, x, f);
+                err += pow(ft_norm_2arg(f, fd, m), 2);
+            #endif
             ft_horner(n, c, 1, m, x, f);
             err += pow(ft_norm_2arg(f, fd, m), 2);
             err = sqrt(err);
@@ -155,20 +167,24 @@ int main(void) {
             //for (int i = 0; i < n; i++)
             //    printf("c[%i] = %3.5f, x[%i] = %3.5f, f[%i] = %3.8f\n", i, c[i], i, x[i], i, f[i]);
 
-            FT_TIME(horner_SSE2(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for horner_SSE2 \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #if defined(__i386__) || defined(__x86_64__)
+                FT_TIME(horner_SSE2(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for horner_SSE2 \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(horner_AVX(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for horner_AVX \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(horner_AVX(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for horner_AVX \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(horner_AVX_FMA(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for horner_AVX_FMA \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(horner_AVX_FMA(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for horner_AVX_FMA \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(horner_AVX512F(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for horner_AVX512F \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(horner_AVX512F(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for horner_AVX512F \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #endif
 
-            FT_TIME(horner_NEON(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for horner_NEON \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #if defined(__aarch64__)
+                FT_TIME(horner_NEON(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for horner_NEON \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #endif
 
             FT_TIME(ft_horner(n, c, 1, m, x, f), start, end, NTIMES)
             printf("Time for ft_horner \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
@@ -197,16 +213,20 @@ int main(void) {
                 x[j] = (-1.0f+2.0f*j/(m-1.0f));
 
             clenshaw_defaultf(n, c, 1, m, x, fd);
-            clenshaw_SSEf(n, c, 1, m, x, f);
-            err = powf(ft_norm_2argf(f, fd, m), 2);
-            clenshaw_AVXf(n, c, 1, m, x, f);
-            err += powf(ft_norm_2argf(f, fd, m), 2);
-            clenshaw_AVX_FMAf(n, c, 1, m, x, f);
-            err += powf(ft_norm_2argf(f, fd, m), 2);
-            clenshaw_AVX512Ff(n, c, 1, m, x, f);
-            err += powf(ft_norm_2argf(f, fd, m), 2);
-            clenshaw_NEONf(n, c, 1, m, x, f);
-            err += powf(ft_norm_2argf(f, fd, m), 2);
+            #if defined(__i386__) || defined(__x86_64__)
+                clenshaw_SSEf(n, c, 1, m, x, f);
+                err += powf(ft_norm_2argf(f, fd, m), 2);
+                clenshaw_AVXf(n, c, 1, m, x, f);
+                err += powf(ft_norm_2argf(f, fd, m), 2);
+                clenshaw_AVX_FMAf(n, c, 1, m, x, f);
+                err += powf(ft_norm_2argf(f, fd, m), 2);
+                clenshaw_AVX512Ff(n, c, 1, m, x, f);
+                err += powf(ft_norm_2argf(f, fd, m), 2);
+            #endif
+            #if defined(__aarch64__)
+                clenshaw_NEONf(n, c, 1, m, x, f);
+                err += powf(ft_norm_2argf(f, fd, m), 2);
+            #endif
             ft_clenshawf(n, c, 1, m, x, f);
             err += powf(ft_norm_2argf(f, fd, m), 2);
             err = sqrtf(err);
@@ -236,20 +256,24 @@ int main(void) {
             //for (int i = 0; i < n; i++)
             //    printf("c[%i] = %3.5f, x[%i] = %3.5f, f[%i] = %3.8f\n", i, c[i], i, x[i], i, f[i]);
 
-            FT_TIME(clenshaw_SSEf(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for clenshaw_SSEf \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #if defined(__i386__) || defined(__x86_64__)
+                FT_TIME(clenshaw_SSEf(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for clenshaw_SSEf \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(clenshaw_AVXf(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for clenshaw_AVXf \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(clenshaw_AVXf(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for clenshaw_AVXf \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(clenshaw_AVX_FMAf(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for clenshaw_AVX_FMAf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(clenshaw_AVX_FMAf(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for clenshaw_AVX_FMAf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(clenshaw_AVX512Ff(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for clenshaw_AVX512Ff \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(clenshaw_AVX512Ff(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for clenshaw_AVX512Ff \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #endif
 
-            FT_TIME(clenshaw_NEONf(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for clenshaw_NEONf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #if defined(__aarch64__)
+                FT_TIME(clenshaw_NEONf(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for clenshaw_NEONf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #endif
 
             FT_TIME(ft_clenshawf(n, c, 1, m, x, f), start, end, NTIMES)
             printf("Time for ft_clenshawf \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
@@ -277,16 +301,20 @@ int main(void) {
                 x[j] = (-1.0+2.0*j/(m-1.0));
 
             clenshaw_default(n, c, 1, m, x, fd);
-            clenshaw_SSE2(n, c, 1, m, x, f);
-            err = pow(ft_norm_2arg(f, fd, m), 2);
-            clenshaw_AVX(n, c, 1, m, x, f);
-            err += pow(ft_norm_2arg(f, fd, m), 2);
-            clenshaw_AVX_FMA(n, c, 1, m, x, f);
-            err += pow(ft_norm_2arg(f, fd, m), 2);
-            clenshaw_AVX512F(n, c, 1, m, x, f);
-            err += pow(ft_norm_2arg(f, fd, m), 2);
-            clenshaw_NEON(n, c, 1, m, x, f);
-            err += pow(ft_norm_2arg(f, fd, m), 2);
+            #if defined(__i386__) || defined(__x86_64__)
+                clenshaw_SSE2(n, c, 1, m, x, f);
+                err += pow(ft_norm_2arg(f, fd, m), 2);
+                clenshaw_AVX(n, c, 1, m, x, f);
+                err += pow(ft_norm_2arg(f, fd, m), 2);
+                clenshaw_AVX_FMA(n, c, 1, m, x, f);
+                err += pow(ft_norm_2arg(f, fd, m), 2);
+                clenshaw_AVX512F(n, c, 1, m, x, f);
+                err += pow(ft_norm_2arg(f, fd, m), 2);
+            #endif
+            #if defined(__aarch64__)
+                clenshaw_NEON(n, c, 1, m, x, f);
+                err += pow(ft_norm_2arg(f, fd, m), 2);
+            #endif
             ft_clenshaw(n, c, 1, m, x, f);
             err += pow(ft_norm_2arg(f, fd, m), 2);
             err = sqrt(err);
@@ -316,20 +344,24 @@ int main(void) {
             //for (int i = 0; i < n; i++)
             //    printf("c[%i] = %3.5f, x[%i] = %3.5f, f[%i] = %3.8f\n", i, c[i], i, x[i], i, f[i]);
 
-            FT_TIME(clenshaw_SSE2(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for clenshaw_SSE2 \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #if defined(__i386__) || defined(__x86_64__)
+                FT_TIME(clenshaw_SSE2(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for clenshaw_SSE2 \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(clenshaw_AVX(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for clenshaw_AVX \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(clenshaw_AVX(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for clenshaw_AVX \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(clenshaw_AVX_FMA(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for clenshaw_AVX_FMA \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(clenshaw_AVX_FMA(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for clenshaw_AVX_FMA \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(clenshaw_AVX512F(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for clenshaw_AVX512F \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(clenshaw_AVX512F(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for clenshaw_AVX512F \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #endif
 
-            FT_TIME(clenshaw_NEON(n, c, 1, m, x, f), start, end, NTIMES)
-            printf("Time for clenshaw_NEON \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #if defined(__aarch64__)
+                FT_TIME(clenshaw_NEON(n, c, 1, m, x, f), start, end, NTIMES)
+                printf("Time for clenshaw_NEON \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #endif
 
             FT_TIME(ft_clenshaw(n, c, 1, m, x, f), start, end, NTIMES)
             printf("Time for ft_clenshaw \t\t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
@@ -369,16 +401,20 @@ int main(void) {
             }
 
             orthogonal_polynomial_clenshaw_defaultf(n, c, 1, A, B, C, m, x, phi0, fd);
-            orthogonal_polynomial_clenshaw_SSEf(n, c, 1, A, B, C, m, x, phi0, f);
-            err = powf(ft_norm_2argf(f, fd, m), 2);
-            orthogonal_polynomial_clenshaw_AVXf(n, c, 1, A, B, C, m, x, phi0, f);
-            err += powf(ft_norm_2argf(f, fd, m), 2);
-            orthogonal_polynomial_clenshaw_AVX_FMAf(n, c, 1, A, B, C, m, x, phi0, f);
-            err += powf(ft_norm_2argf(f, fd, m), 2);
-            orthogonal_polynomial_clenshaw_AVX512Ff(n, c, 1, A, B, C, m, x, phi0, f);
-            err += powf(ft_norm_2argf(f, fd, m), 2);
-            orthogonal_polynomial_clenshaw_NEONf(n, c, 1, A, B, C, m, x, phi0, f);
-            err += powf(ft_norm_2argf(f, fd, m), 2);
+            #if defined(__i386__) || defined(__x86_64__)
+                orthogonal_polynomial_clenshaw_SSEf(n, c, 1, A, B, C, m, x, phi0, f);
+                err += powf(ft_norm_2argf(f, fd, m), 2);
+                orthogonal_polynomial_clenshaw_AVXf(n, c, 1, A, B, C, m, x, phi0, f);
+                err += powf(ft_norm_2argf(f, fd, m), 2);
+                orthogonal_polynomial_clenshaw_AVX_FMAf(n, c, 1, A, B, C, m, x, phi0, f);
+                err += powf(ft_norm_2argf(f, fd, m), 2);
+                orthogonal_polynomial_clenshaw_AVX512Ff(n, c, 1, A, B, C, m, x, phi0, f);
+                err += powf(ft_norm_2argf(f, fd, m), 2);
+            #endif
+            #if defined(__aarch64__)
+                orthogonal_polynomial_clenshaw_NEONf(n, c, 1, A, B, C, m, x, phi0, f);
+                err += powf(ft_norm_2argf(f, fd, m), 2);
+            #endif
             ft_orthogonal_polynomial_clenshawf(n, c, 1, A, B, C, m, x, phi0, f);
             err += powf(ft_norm_2argf(f, fd, m), 2);
             err = sqrtf(err);
@@ -424,20 +460,24 @@ int main(void) {
             //for (int i = 0; i < n; i++)
             //    printf("c[%i] = %3.5f, x[%i] = %3.5f, f[%i] = %3.8f\n", i, c[i], i, x[i], i, f[i]);
 
-            FT_TIME(orthogonal_polynomial_clenshaw_SSEf(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
-            printf("Time for OP clenshaw_SSEf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #if defined(__i386__) || defined(__x86_64__)
+                FT_TIME(orthogonal_polynomial_clenshaw_SSEf(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
+                printf("Time for OP clenshaw_SSEf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(orthogonal_polynomial_clenshaw_AVXf(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
-            printf("Time for OP clenshaw_AVXf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(orthogonal_polynomial_clenshaw_AVXf(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
+                printf("Time for OP clenshaw_AVXf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(orthogonal_polynomial_clenshaw_AVX_FMAf(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
-            printf("Time for OP clenshaw_AVX_FMAf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(orthogonal_polynomial_clenshaw_AVX_FMAf(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
+                printf("Time for OP clenshaw_AVX_FMAf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(orthogonal_polynomial_clenshaw_AVX512Ff(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
-            printf("Time for OP clenshaw_AVX512Ff \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(orthogonal_polynomial_clenshaw_AVX512Ff(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
+                printf("Time for OP clenshaw_AVX512Ff \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #endif
 
-            FT_TIME(orthogonal_polynomial_clenshaw_NEONf(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
-            printf("Time for OP clenshaw_NEONf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #if defined(__aarch64__)
+                FT_TIME(orthogonal_polynomial_clenshaw_NEONf(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
+                printf("Time for OP clenshaw_NEONf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #endif
 
             FT_TIME(ft_orthogonal_polynomial_clenshawf(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
             printf("Time for OP ft_clenshawf \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
@@ -480,16 +520,20 @@ int main(void) {
             }
 
             orthogonal_polynomial_clenshaw_default(n, c, 1, A, B, C, m, x, phi0, fd);
-            orthogonal_polynomial_clenshaw_SSE2(n, c, 1, A, B, C, m, x, phi0, f);
-            err = pow(ft_norm_2arg(f, fd, m), 2);
-            orthogonal_polynomial_clenshaw_AVX(n, c, 1, A, B, C, m, x, phi0, f);
-            err += pow(ft_norm_2arg(f, fd, m), 2);
-            orthogonal_polynomial_clenshaw_AVX_FMA(n, c, 1, A, B, C, m, x, phi0, f);
-            err += pow(ft_norm_2arg(f, fd, m), 2);
-            orthogonal_polynomial_clenshaw_AVX512F(n, c, 1, A, B, C, m, x, phi0, f);
-            err += pow(ft_norm_2arg(f, fd, m), 2);
-            orthogonal_polynomial_clenshaw_NEON(n, c, 1, A, B, C, m, x, phi0, f);
-            err += pow(ft_norm_2arg(f, fd, m), 2);
+            #if defined(__i386__) || defined(__x86_64__)
+                orthogonal_polynomial_clenshaw_SSE2(n, c, 1, A, B, C, m, x, phi0, f);
+                err += pow(ft_norm_2arg(f, fd, m), 2);
+                orthogonal_polynomial_clenshaw_AVX(n, c, 1, A, B, C, m, x, phi0, f);
+                err += pow(ft_norm_2arg(f, fd, m), 2);
+                orthogonal_polynomial_clenshaw_AVX_FMA(n, c, 1, A, B, C, m, x, phi0, f);
+                err += pow(ft_norm_2arg(f, fd, m), 2);
+                orthogonal_polynomial_clenshaw_AVX512F(n, c, 1, A, B, C, m, x, phi0, f);
+                err += pow(ft_norm_2arg(f, fd, m), 2);
+            #endif
+            #if defined(__aarch64__)
+                orthogonal_polynomial_clenshaw_NEON(n, c, 1, A, B, C, m, x, phi0, f);
+                err += pow(ft_norm_2arg(f, fd, m), 2);
+            #endif
             ft_orthogonal_polynomial_clenshaw(n, c, 1, A, B, C, m, x, phi0, f);
             err += pow(ft_norm_2arg(f, fd, m), 2);
             err = sqrt(err);
@@ -535,20 +579,24 @@ int main(void) {
             //for (int i = 0; i < n; i++)
             //    printf("c[%i] = %3.5f, x[%i] = %3.5f, f[%i] = %3.8f\n", i, c[i], i, x[i], i, f[i]);
 
-            FT_TIME(orthogonal_polynomial_clenshaw_SSE2(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
-            printf("Time for OP clenshaw_SSE2 \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #if defined(__i386__) || defined(__x86_64__)
+                FT_TIME(orthogonal_polynomial_clenshaw_SSE2(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
+                printf("Time for OP clenshaw_SSE2 \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(orthogonal_polynomial_clenshaw_AVX(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
-            printf("Time for OP clenshaw_AVX \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(orthogonal_polynomial_clenshaw_AVX(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
+                printf("Time for OP clenshaw_AVX \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(orthogonal_polynomial_clenshaw_AVX_FMA(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
-            printf("Time for OP clenshaw_AVX_FMA \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(orthogonal_polynomial_clenshaw_AVX_FMA(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
+                printf("Time for OP clenshaw_AVX_FMA \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
 
-            FT_TIME(orthogonal_polynomial_clenshaw_AVX512F(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
-            printf("Time for OP clenshaw_AVX512F \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+                FT_TIME(orthogonal_polynomial_clenshaw_AVX512F(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
+                printf("Time for OP clenshaw_AVX512F \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #endif
 
-            FT_TIME(orthogonal_polynomial_clenshaw_NEON(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
-            printf("Time for OP clenshaw_NEON \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #if defined(__aarch64__)
+                FT_TIME(orthogonal_polynomial_clenshaw_NEON(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
+                printf("Time for OP clenshaw_NEON \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));
+            #endif
 
             FT_TIME(ft_orthogonal_polynomial_clenshaw(n, c, 1, A, B, C, m, x, phi0, f), start, end, NTIMES)
             printf("Time for OP ft_clenshaw \t\t (%5i×%5i) \t |%20.6f s\n", m, n, elapsed(&start, &end, NTIMES));

--- a/test/test_rotations.c
+++ b/test/test_rotations.c
@@ -614,7 +614,7 @@ int main(void) {
                         kernel_sph_lo2hi_default(RP, am%2, am, A, 2);
                         kernel_sph_lo2hi_default(RP, am%2, am, A+1, 2);
                         err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-                    #elif defied(__aarch64__)
+                    #elif defined(__aarch64__)
                         kernel_sph_hi2lo_default(RP, am%2, am, A, 2);
                         kernel_sph_hi2lo_default(RP, am%2, am, A+1, 2);
                         kernel_spinsph_lo2hi_NEON(SRP, m, AC, 1);

--- a/test/test_rotations.c
+++ b/test/test_rotations.c
@@ -62,6 +62,18 @@ int main(void) {
             kernel_sph_lo2hi_default(RP, m%2, m, A, 1);
             kernel_sph_lo2hi_default(RP, m%2, m, A+n, 1);
             err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+            kernel_sph_hi2lo_default(RP, m%2, m, A, 1);
+            kernel_sph_hi2lo_default(RP, m%2, m, A+n, 1);
+            permute(A, Ac, n, 2, 2);
+            kernel_sph_lo2hi_NEON(RP, m%2, m, Ac, 2);
+            permute_t(A, Ac, n, 2, 2);
+            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+            permute(A, Ac, n, 2, 2);
+            kernel_sph_hi2lo_NEON(RP, m%2, m, Ac, 2);
+            permute_t(A, Ac, n, 2, 2);
+            kernel_sph_lo2hi_default(RP, m%2, m, A, 1);
+            kernel_sph_lo2hi_default(RP, m%2, m, A+n, 1);
+            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
         }
         err = sqrt(err);
         printf("Applying the rotations with two   columns at n = %3i: \t |%20.2e ", n, err);
@@ -213,10 +225,22 @@ int main(void) {
             kernel_tri_lo2hi_default(RP, 0, m, A, 1);
             kernel_tri_lo2hi_default(RP, 0, m+1, A+n, 1);
             err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+            kernel_tri_hi2lo_default(RP, 0, m, A, 1);
+            kernel_tri_hi2lo_default(RP, 0, m+1, A+n, 1);
+            permute(A, Ac, n, 2, 2);
+            kernel_tri_lo2hi_NEON(RP, 0, m, Ac, 2);
+            permute_t(A, Ac, n, 2, 2);
+            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+            permute(A, Ac, n, 2, 2);
+            kernel_tri_hi2lo_NEON(RP, 0, m, Ac, 2);
+            permute_t(A, Ac, n, 2, 2);
+            kernel_tri_lo2hi_default(RP, 0, m, A, 1);
+            kernel_tri_lo2hi_default(RP, 0, m+1, A+n, 1);
+            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
         }
         err = sqrt(err);
         printf("Applying the rotations with two   columns at n = %3i: \t |%20.2e ", n, err);
-        ft_checktest(err, 2*n, &checksum);
+        ft_checktest(err, 3*n, &checksum);
         free(A);
         VFREE(Ac);
         free(B);
@@ -361,10 +385,22 @@ int main(void) {
             kernel_disk_lo2hi_default(RP, m%2, m, A, 1);
             kernel_disk_lo2hi_default(RP, m%2, m, A+n, 1);
             err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+            kernel_disk_hi2lo_default(RP, m%2, m, A, 1);
+            kernel_disk_hi2lo_default(RP, m%2, m, A+n, 1);
+            permute(A, Ac, n, 2, 2);
+            kernel_disk_lo2hi_NEON(RP, m%2, m, Ac, 2);
+            permute_t(A, Ac, n, 2, 2);
+            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+            permute(A, Ac, n, 2, 2);
+            kernel_disk_hi2lo_NEON(RP, m%2, m, Ac, 2);
+            permute_t(A, Ac, n, 2, 2);
+            kernel_disk_lo2hi_default(RP, m%2, m, A, 1);
+            kernel_disk_lo2hi_default(RP, m%2, m, A+n, 1);
+            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
         }
         err = sqrt(err);
         printf("Applying the rotations with two   columns at n = %3i: \t |%20.2e ", n, err);
-        ft_checktest(err, 2*n, &checksum);
+        ft_checktest(err, 3*n, &checksum);
         free(A);
         VFREE(Ac);
         free(B);
@@ -488,10 +524,20 @@ int main(void) {
                 kernel_spinsph_hi2lo_SSE2(SRP, m, AC, 1);
                 kernel_spinsph_lo2hi_default(SRP, m, AC, 1);
                 err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                kernel_spinsph_hi2lo_default(SRP, m, AC, 1);
+                kernel_spinsph_lo2hi_NEON(SRP, m, AC, 1);
+                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                kernel_spinsph_hi2lo_NEON(SRP, m, AC, 1);
+                kernel_spinsph_lo2hi_default(SRP, m, AC, 1);
+                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
                 if (s == 0) {
                     kernel_spinsph_hi2lo_default(SRP, m, AC, 1);
                     kernel_sph_lo2hi_default(RP, am%2, am, A, 2);
                     kernel_sph_lo2hi_default(RP, am%2, am, A+1, 2);
+                    err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                    kernel_sph_hi2lo_default(RP, am%2, am, A, 2);
+                    kernel_sph_hi2lo_default(RP, am%2, am, A+1, 2);
+                    kernel_spinsph_lo2hi_default(SRP, m, AC, 1);
                     err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
                     kernel_sph_hi2lo_default(RP, am%2, am, A, 2);
                     kernel_sph_hi2lo_default(RP, am%2, am, A+1, 2);
@@ -503,14 +549,18 @@ int main(void) {
                     err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
                     kernel_sph_hi2lo_default(RP, am%2, am, A, 2);
                     kernel_sph_hi2lo_default(RP, am%2, am, A+1, 2);
-                    kernel_spinsph_lo2hi_default(SRP, m, AC, 1);
+                    kernel_spinsph_lo2hi_NEON(SRP, m, AC, 1);
+                    err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                    kernel_spinsph_hi2lo_NEON(SRP, m, AC, 1);
+                    kernel_sph_lo2hi_default(RP, am%2, am, A, 2);
+                    kernel_sph_lo2hi_default(RP, am%2, am, A+1, 2);
                     err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
                 }
             }
-            if (s == 0) err /= 6.0;
+            if (s == 0) err /= 9.0;
             err = sqrt(err);
             printf("Applying the rotations with spin s = %2i at n = %3i: \t |%20.2e ", s, n, err);
-            ft_checktest(err, 2*n, &checksum);
+            ft_checktest(err, 3*n, &checksum);
             free(A);
             free(B);
             ft_destroy_rotation_plan(RP);

--- a/test/test_rotations.c
+++ b/test/test_rotations.c
@@ -39,139 +39,160 @@ int main(void) {
         free(A);
         free(B);
 
-        err = 0;
-        A = calloc(2*n, sizeof(double));
-        Ac = VMALLOC(2*n*sizeof(double));
-        B = calloc(2*n, sizeof(double));
-        for (int m = 2; m < n; m++) {
-            for (int i = 0; i < n-m; i++) {
-                A[i] = Ac[i] = B[i] = 1.0;
-                A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
+        #if defined(__i386__) || defined(__x86_64__)
+            err = 0;
+            A = calloc(2*n, sizeof(double));
+            Ac = VMALLOC(2*n*sizeof(double));
+            B = calloc(2*n, sizeof(double));
+            for (int m = 2; m < n; m++) {
+                for (int i = 0; i < n-m; i++) {
+                    A[i] = Ac[i] = B[i] = 1.0;
+                    A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
+                }
+                for (int i = n-m; i < n; i++)
+                    A[i] = A[i+n] = Ac[i] = Ac[i+n] = B[i] = B[i+n] = 0.0;
+                kernel_sph_hi2lo_default(RP, m%2, m, A, 1);
+                kernel_sph_hi2lo_default(RP, m%2, m, A+n, 1);
+                permute(A, Ac, n, 2, 2);
+                kernel_sph_lo2hi_SSE2(RP, m%2, m, Ac, 2);
+                permute_t(A, Ac, n, 2, 2);
+                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                permute(A, Ac, n, 2, 2);
+                kernel_sph_hi2lo_SSE2(RP, m%2, m, Ac, 2);
+                permute_t(A, Ac, n, 2, 2);
+                kernel_sph_lo2hi_default(RP, m%2, m, A, 1);
+                kernel_sph_lo2hi_default(RP, m%2, m, A+n, 1);
+                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
             }
-            for (int i = n-m; i < n; i++)
-                A[i] = A[i+n] = Ac[i] = Ac[i+n] = B[i] = B[i+n] = 0.0;
-            kernel_sph_hi2lo_default(RP, m%2, m, A, 1);
-            kernel_sph_hi2lo_default(RP, m%2, m, A+n, 1);
-            permute(A, Ac, n, 2, 2);
-            kernel_sph_lo2hi_SSE2(RP, m%2, m, Ac, 2);
-            permute_t(A, Ac, n, 2, 2);
-            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-            permute(A, Ac, n, 2, 2);
-            kernel_sph_hi2lo_SSE2(RP, m%2, m, Ac, 2);
-            permute_t(A, Ac, n, 2, 2);
-            kernel_sph_lo2hi_default(RP, m%2, m, A, 1);
-            kernel_sph_lo2hi_default(RP, m%2, m, A+n, 1);
-            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-            kernel_sph_hi2lo_default(RP, m%2, m, A, 1);
-            kernel_sph_hi2lo_default(RP, m%2, m, A+n, 1);
-            permute(A, Ac, n, 2, 2);
-            kernel_sph_lo2hi_NEON(RP, m%2, m, Ac, 2);
-            permute_t(A, Ac, n, 2, 2);
-            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-            permute(A, Ac, n, 2, 2);
-            kernel_sph_hi2lo_NEON(RP, m%2, m, Ac, 2);
-            permute_t(A, Ac, n, 2, 2);
-            kernel_sph_lo2hi_default(RP, m%2, m, A, 1);
-            kernel_sph_lo2hi_default(RP, m%2, m, A+n, 1);
-            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-        }
-        err = sqrt(err);
-        printf("Applying the rotations with two   columns at n = %3i: \t |%20.2e ", n, err);
-        ft_checktest(err, 2*n, &checksum);
-        free(A);
-        VFREE(Ac);
-        free(B);
+            err = sqrt(err);
+            printf("Applying the rotations with two   columns at n = %3i: \t |%20.2e ", n, err);
+            ft_checktest(err, 2*n, &checksum);
+            free(A);
+            VFREE(Ac);
+            free(B);
 
-        err = 0;
-        A = calloc(4*n, sizeof(double));
-        Ac = VMALLOC(4*n*sizeof(double));
-        B = calloc(4*n, sizeof(double));
-        for (int m = 2; m < n; m++) {
-            for (int i = 0; i < n-m; i++) {
-                A[i] = Ac[i] = B[i] = 1.0;
-                A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
-                A[i+2*n] = Ac[i+2*n] = B[i+2*n] = 1.0/pow(i+1, 2);
-                A[i+3*n] = Ac[i+3*n] = B[i+3*n] = 1.0/pow(i+1, 3);
+            err = 0;
+            A = calloc(4*n, sizeof(double));
+            Ac = VMALLOC(4*n*sizeof(double));
+            B = calloc(4*n, sizeof(double));
+            for (int m = 2; m < n; m++) {
+                for (int i = 0; i < n-m; i++) {
+                    A[i] = Ac[i] = B[i] = 1.0;
+                    A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
+                    A[i+2*n] = Ac[i+2*n] = B[i+2*n] = 1.0/pow(i+1, 2);
+                    A[i+3*n] = Ac[i+3*n] = B[i+3*n] = 1.0/pow(i+1, 3);
+                }
+                for (int i = n-m; i < n; i++)
+                    A[i] = A[i+n] = A[i+2*n] = A[i+3*n] = Ac[i] = Ac[i+n] = Ac[i+2*n] = Ac[i+3*n] = B[i] = B[i+n] = B[i+2*n] = B[i+3*n] = 0.0;
+                kernel_sph_hi2lo_default(RP, m%2, m, A, 1);
+                kernel_sph_hi2lo_default(RP, m%2, m, A+n, 1);
+                kernel_sph_hi2lo_default(RP, m%2, m+2, A+2*n, 1);
+                kernel_sph_hi2lo_default(RP, m%2, m+2, A+3*n, 1);
+                permute(A, Ac, n, 4, 4);
+                kernel_sph_lo2hi_AVX_FMA(RP, m%2, m, Ac, 4);
+                permute_t(A, Ac, n, 4, 4);
+                err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
+                permute(A, Ac, n, 4, 4);
+                kernel_sph_hi2lo_AVX(RP, m%2, m, Ac, 4);
+                permute_t(A, Ac, n, 4, 4);
+                kernel_sph_lo2hi_default(RP, m%2, m, A, 1);
+                kernel_sph_lo2hi_default(RP, m%2, m, A+n, 1);
+                kernel_sph_lo2hi_default(RP, m%2, m+2, A+2*n, 1);
+                kernel_sph_lo2hi_default(RP, m%2, m+2, A+3*n, 1);
+                err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
+                permute(A, Ac, n, 4, 4);
+                kernel_sph_hi2lo_AVX_FMA(RP, m%2, m, Ac, 4);
+                kernel_sph_lo2hi_AVX(RP, m%2, m, Ac, 4);
+                permute_t(A, Ac, n, 4, 4);
+                err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
             }
-            for (int i = n-m; i < n; i++)
-                A[i] = A[i+n] = A[i+2*n] = A[i+3*n] = Ac[i] = Ac[i+n] = Ac[i+2*n] = Ac[i+3*n] = B[i] = B[i+n] = B[i+2*n] = B[i+3*n] = 0.0;
-            kernel_sph_hi2lo_default(RP, m%2, m, A, 1);
-            kernel_sph_hi2lo_default(RP, m%2, m, A+n, 1);
-            kernel_sph_hi2lo_default(RP, m%2, m+2, A+2*n, 1);
-            kernel_sph_hi2lo_default(RP, m%2, m+2, A+3*n, 1);
-            permute(A, Ac, n, 4, 4);
-            kernel_sph_lo2hi_AVX_FMA(RP, m%2, m, Ac, 4);
-            permute_t(A, Ac, n, 4, 4);
-            err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
-            permute(A, Ac, n, 4, 4);
-            kernel_sph_hi2lo_AVX(RP, m%2, m, Ac, 4);
-            permute_t(A, Ac, n, 4, 4);
-            kernel_sph_lo2hi_default(RP, m%2, m, A, 1);
-            kernel_sph_lo2hi_default(RP, m%2, m, A+n, 1);
-            kernel_sph_lo2hi_default(RP, m%2, m+2, A+2*n, 1);
-            kernel_sph_lo2hi_default(RP, m%2, m+2, A+3*n, 1);
-            err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
-            permute(A, Ac, n, 4, 4);
-            kernel_sph_hi2lo_AVX_FMA(RP, m%2, m, Ac, 4);
-            kernel_sph_lo2hi_AVX(RP, m%2, m, Ac, 4);
-            permute_t(A, Ac, n, 4, 4);
-            err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
-        }
-        err = sqrt(err);
-        printf("Applying the rotations with four  columns at n = %3i: \t |%20.2e ", n, err);
-        ft_checktest(err, 2*n, &checksum);
-        free(A);
-        VFREE(Ac);
-        free(B);
+            err = sqrt(err);
+            printf("Applying the rotations with four  columns at n = %3i: \t |%20.2e ", n, err);
+            ft_checktest(err, 2*n, &checksum);
+            free(A);
+            VFREE(Ac);
+            free(B);
 
-        err = 0;
-        A = calloc(8*n, sizeof(double));
-        Ac = VMALLOC(8*n*sizeof(double));
-        B = calloc(8*n, sizeof(double));
-        for (int m = 2; m < n; m++) {
-            for (int i = 0; i < n-m; i++) {
-                A[i] = Ac[i] = B[i] = 1.0;
-                A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
-                A[i+2*n] = Ac[i+2*n] = B[i+2*n] = 1.0/pow(i+1, 2);
-                A[i+3*n] = Ac[i+3*n] = B[i+3*n] = 1.0/pow(i+1, 3);
-                A[i+4*n] = Ac[i+4*n] = B[i+4*n] = 1.0/pow(i+1, 4);
-                A[i+5*n] = Ac[i+5*n] = B[i+5*n] = 1.0/pow(i+1, 5);
-                A[i+6*n] = Ac[i+6*n] = B[i+6*n] = 1.0/pow(i+1, 6);
-                A[i+7*n] = Ac[i+7*n] = B[i+7*n] = 1.0/pow(i+1, 7);
+            err = 0;
+            A = calloc(8*n, sizeof(double));
+            Ac = VMALLOC(8*n*sizeof(double));
+            B = calloc(8*n, sizeof(double));
+            for (int m = 2; m < n; m++) {
+                for (int i = 0; i < n-m; i++) {
+                    A[i] = Ac[i] = B[i] = 1.0;
+                    A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
+                    A[i+2*n] = Ac[i+2*n] = B[i+2*n] = 1.0/pow(i+1, 2);
+                    A[i+3*n] = Ac[i+3*n] = B[i+3*n] = 1.0/pow(i+1, 3);
+                    A[i+4*n] = Ac[i+4*n] = B[i+4*n] = 1.0/pow(i+1, 4);
+                    A[i+5*n] = Ac[i+5*n] = B[i+5*n] = 1.0/pow(i+1, 5);
+                    A[i+6*n] = Ac[i+6*n] = B[i+6*n] = 1.0/pow(i+1, 6);
+                    A[i+7*n] = Ac[i+7*n] = B[i+7*n] = 1.0/pow(i+1, 7);
+                }
+                for (int i = n-m; i < n; i++)
+                    A[i] = A[i+n] = A[i+2*n] = A[i+3*n] = A[i+4*n] = A[i+5*n] = A[i+6*n] = A[i+7*n] = Ac[i] = Ac[i+n] = Ac[i+2*n] = Ac[i+3*n] = Ac[i+4*n] = Ac[i+5*n] = Ac[i+6*n] = Ac[i+7*n] = B[i] = B[i+n] = B[i+2*n] = B[i+3*n] = B[i+4*n] = B[i+5*n] = B[i+6*n] = B[i+7*n] = 0.0;
+                kernel_sph_hi2lo_default(RP, m%2, m, A, 1);
+                kernel_sph_hi2lo_default(RP, m%2, m, A+n, 1);
+                kernel_sph_hi2lo_default(RP, m%2, m+2, A+2*n, 1);
+                kernel_sph_hi2lo_default(RP, m%2, m+2, A+3*n, 1);
+                kernel_sph_hi2lo_default(RP, m%2, m+4, A+4*n, 1);
+                kernel_sph_hi2lo_default(RP, m%2, m+4, A+5*n, 1);
+                kernel_sph_hi2lo_default(RP, m%2, m+6, A+6*n, 1);
+                kernel_sph_hi2lo_default(RP, m%2, m+6, A+7*n, 1);
+                permute(A, Ac, n, 8, 8);
+                kernel_sph_lo2hi_AVX512F(RP, m%2, m, Ac, 8);
+                permute_t(A, Ac, n, 8, 8);
+                err += pow(ft_norm_2arg(A, B, 8*n)/ft_norm_1arg(B, 8*n), 2);
+                permute(A, Ac, n, 8, 8);
+                kernel_sph_hi2lo_AVX512F(RP, m%2, m, Ac, 8);
+                permute_t(A, Ac, n, 8, 8);
+                kernel_sph_lo2hi_default(RP, m%2, m, A, 1);
+                kernel_sph_lo2hi_default(RP, m%2, m, A+n, 1);
+                kernel_sph_lo2hi_default(RP, m%2, m+2, A+2*n, 1);
+                kernel_sph_lo2hi_default(RP, m%2, m+2, A+3*n, 1);
+                kernel_sph_lo2hi_default(RP, m%2, m+4, A+4*n, 1);
+                kernel_sph_lo2hi_default(RP, m%2, m+4, A+5*n, 1);
+                kernel_sph_lo2hi_default(RP, m%2, m+6, A+6*n, 1);
+                kernel_sph_lo2hi_default(RP, m%2, m+6, A+7*n, 1);
+                err += pow(ft_norm_2arg(A, B, 8*n)/ft_norm_1arg(B, 8*n), 2);
             }
-            for (int i = n-m; i < n; i++)
-                A[i] = A[i+n] = A[i+2*n] = A[i+3*n] = A[i+4*n] = A[i+5*n] = A[i+6*n] = A[i+7*n] = Ac[i] = Ac[i+n] = Ac[i+2*n] = Ac[i+3*n] = Ac[i+4*n] = Ac[i+5*n] = Ac[i+6*n] = Ac[i+7*n] = B[i] = B[i+n] = B[i+2*n] = B[i+3*n] = B[i+4*n] = B[i+5*n] = B[i+6*n] = B[i+7*n] = 0.0;
-            kernel_sph_hi2lo_default(RP, m%2, m, A, 1);
-            kernel_sph_hi2lo_default(RP, m%2, m, A+n, 1);
-            kernel_sph_hi2lo_default(RP, m%2, m+2, A+2*n, 1);
-            kernel_sph_hi2lo_default(RP, m%2, m+2, A+3*n, 1);
-            kernel_sph_hi2lo_default(RP, m%2, m+4, A+4*n, 1);
-            kernel_sph_hi2lo_default(RP, m%2, m+4, A+5*n, 1);
-            kernel_sph_hi2lo_default(RP, m%2, m+6, A+6*n, 1);
-            kernel_sph_hi2lo_default(RP, m%2, m+6, A+7*n, 1);
-            permute(A, Ac, n, 8, 8);
-            kernel_sph_lo2hi_AVX512F(RP, m%2, m, Ac, 8);
-            permute_t(A, Ac, n, 8, 8);
-            err += pow(ft_norm_2arg(A, B, 8*n)/ft_norm_1arg(B, 8*n), 2);
-            permute(A, Ac, n, 8, 8);
-            kernel_sph_hi2lo_AVX512F(RP, m%2, m, Ac, 8);
-            permute_t(A, Ac, n, 8, 8);
-            kernel_sph_lo2hi_default(RP, m%2, m, A, 1);
-            kernel_sph_lo2hi_default(RP, m%2, m, A+n, 1);
-            kernel_sph_lo2hi_default(RP, m%2, m+2, A+2*n, 1);
-            kernel_sph_lo2hi_default(RP, m%2, m+2, A+3*n, 1);
-            kernel_sph_lo2hi_default(RP, m%2, m+4, A+4*n, 1);
-            kernel_sph_lo2hi_default(RP, m%2, m+4, A+5*n, 1);
-            kernel_sph_lo2hi_default(RP, m%2, m+6, A+6*n, 1);
-            kernel_sph_lo2hi_default(RP, m%2, m+6, A+7*n, 1);
-            err += pow(ft_norm_2arg(A, B, 8*n)/ft_norm_1arg(B, 8*n), 2);
-        }
-        err = sqrt(err);
-        printf("Applying the rotations with eight columns at n = %3i: \t |%20.2e ", n, err);
-        ft_checktest(err, 2*n, &checksum);
-        free(A);
-        VFREE(Ac);
-        free(B);
+            err = sqrt(err);
+            printf("Applying the rotations with eight columns at n = %3i: \t |%20.2e ", n, err);
+            ft_checktest(err, 2*n, &checksum);
+            free(A);
+            VFREE(Ac);
+            free(B);
+        #elif defined(__aarch64__)
+            err = 0;
+            A = calloc(2*n, sizeof(double));
+            Ac = VMALLOC(2*n*sizeof(double));
+            B = calloc(2*n, sizeof(double));
+            for (int m = 2; m < n; m++) {
+                for (int i = 0; i < n-m; i++) {
+                    A[i] = Ac[i] = B[i] = 1.0;
+                    A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
+                }
+                for (int i = n-m; i < n; i++)
+                    A[i] = A[i+n] = Ac[i] = Ac[i+n] = B[i] = B[i+n] = 0.0;
+                kernel_sph_hi2lo_default(RP, m%2, m, A, 1);
+                kernel_sph_hi2lo_default(RP, m%2, m, A+n, 1);
+                permute(A, Ac, n, 2, 2);
+                kernel_sph_lo2hi_NEON(RP, m%2, m, Ac, 2);
+                permute_t(A, Ac, n, 2, 2);
+                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                permute(A, Ac, n, 2, 2);
+                kernel_sph_hi2lo_NEON(RP, m%2, m, Ac, 2);
+                permute_t(A, Ac, n, 2, 2);
+                kernel_sph_lo2hi_default(RP, m%2, m, A, 1);
+                kernel_sph_lo2hi_default(RP, m%2, m, A+n, 1);
+                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+            }
+            err = sqrt(err);
+            printf("Applying the rotations with two   columns at n = %3i: \t |%20.2e ", n, err);
+            ft_checktest(err, 2*n, &checksum);
+            free(A);
+            VFREE(Ac);
+            free(B);
+        #endif
         ft_destroy_rotation_plan(RP);
     }
 
@@ -202,139 +223,160 @@ int main(void) {
         free(A);
         free(B);
 
-        err = 0;
-        A = calloc(2*n, sizeof(double));
-        Ac = VMALLOC(2*n*sizeof(double));
-        B = calloc(2*n, sizeof(double));
-        for (int m = 1; m < n; m++) {
-            for (int i = 0; i < n-m; i++) {
-                A[i] = Ac[i] = B[i] = 1.0;
-                A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
+        #if defined(__i386__) || defined(__x86_64__)
+            err = 0;
+            A = calloc(2*n, sizeof(double));
+            Ac = VMALLOC(2*n*sizeof(double));
+            B = calloc(2*n, sizeof(double));
+            for (int m = 1; m < n; m++) {
+                for (int i = 0; i < n-m; i++) {
+                    A[i] = Ac[i] = B[i] = 1.0;
+                    A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
+                }
+                for (int i = n-m; i < n; i++)
+                    A[i] = A[i+n] = Ac[i] = Ac[i+n] = B[i] = B[i+n] = 0.0;
+                kernel_tri_hi2lo_default(RP, 0, m, A, 1);
+                kernel_tri_hi2lo_default(RP, 0, m+1, A+n, 1);
+                permute(A, Ac, n, 2, 2);
+                kernel_tri_lo2hi_SSE2(RP, 0, m, Ac, 2);
+                permute_t(A, Ac, n, 2, 2);
+                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                permute(A, Ac, n, 2, 2);
+                kernel_tri_hi2lo_SSE2(RP, 0, m, Ac, 2);
+                permute_t(A, Ac, n, 2, 2);
+                kernel_tri_lo2hi_default(RP, 0, m, A, 1);
+                kernel_tri_lo2hi_default(RP, 0, m+1, A+n, 1);
+                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
             }
-            for (int i = n-m; i < n; i++)
-                A[i] = A[i+n] = Ac[i] = Ac[i+n] = B[i] = B[i+n] = 0.0;
-            kernel_tri_hi2lo_default(RP, 0, m, A, 1);
-            kernel_tri_hi2lo_default(RP, 0, m+1, A+n, 1);
-            permute(A, Ac, n, 2, 2);
-            kernel_tri_lo2hi_SSE2(RP, 0, m, Ac, 2);
-            permute_t(A, Ac, n, 2, 2);
-            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-            permute(A, Ac, n, 2, 2);
-            kernel_tri_hi2lo_SSE2(RP, 0, m, Ac, 2);
-            permute_t(A, Ac, n, 2, 2);
-            kernel_tri_lo2hi_default(RP, 0, m, A, 1);
-            kernel_tri_lo2hi_default(RP, 0, m+1, A+n, 1);
-            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-            kernel_tri_hi2lo_default(RP, 0, m, A, 1);
-            kernel_tri_hi2lo_default(RP, 0, m+1, A+n, 1);
-            permute(A, Ac, n, 2, 2);
-            kernel_tri_lo2hi_NEON(RP, 0, m, Ac, 2);
-            permute_t(A, Ac, n, 2, 2);
-            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-            permute(A, Ac, n, 2, 2);
-            kernel_tri_hi2lo_NEON(RP, 0, m, Ac, 2);
-            permute_t(A, Ac, n, 2, 2);
-            kernel_tri_lo2hi_default(RP, 0, m, A, 1);
-            kernel_tri_lo2hi_default(RP, 0, m+1, A+n, 1);
-            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-        }
-        err = sqrt(err);
-        printf("Applying the rotations with two   columns at n = %3i: \t |%20.2e ", n, err);
-        ft_checktest(err, 3*n, &checksum);
-        free(A);
-        VFREE(Ac);
-        free(B);
+            err = sqrt(err);
+            printf("Applying the rotations with two   columns at n = %3i: \t |%20.2e ", n, err);
+            ft_checktest(err, 2*n, &checksum);
+            free(A);
+            VFREE(Ac);
+            free(B);
 
-        err = 0;
-        A = calloc(4*n, sizeof(double));
-        Ac = VMALLOC(4*n*sizeof(double));
-        B = calloc(4*n, sizeof(double));
-        for (int m = 1; m < n; m++) {
-            for (int i = 0; i < n-m; i++) {
-                A[i] = Ac[i] = B[i] = 1.0;
-                A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
-                A[i+2*n] = Ac[i+2*n] = B[i+2*n] = 1.0/pow(i+1, 2);
-                A[i+3*n] = Ac[i+3*n] = B[i+3*n] = 1.0/pow(i+1, 3);
+            err = 0;
+            A = calloc(4*n, sizeof(double));
+            Ac = VMALLOC(4*n*sizeof(double));
+            B = calloc(4*n, sizeof(double));
+            for (int m = 1; m < n; m++) {
+                for (int i = 0; i < n-m; i++) {
+                    A[i] = Ac[i] = B[i] = 1.0;
+                    A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
+                    A[i+2*n] = Ac[i+2*n] = B[i+2*n] = 1.0/pow(i+1, 2);
+                    A[i+3*n] = Ac[i+3*n] = B[i+3*n] = 1.0/pow(i+1, 3);
+                }
+                for (int i = n-m; i < n; i++)
+                    A[i] = A[i+n] = A[i+2*n] = A[i+3*n] = Ac[i] = Ac[i+n] = Ac[i+2*n] = Ac[i+3*n] = B[i] = B[i+n] = B[i+2*n] = B[i+3*n] = 0.0;
+                kernel_tri_hi2lo_default(RP, 0, m, A, 1);
+                kernel_tri_hi2lo_default(RP, 0, m+1, A+n, 1);
+                kernel_tri_hi2lo_default(RP, 0, m+2, A+2*n, 1);
+                kernel_tri_hi2lo_default(RP, 0, m+3, A+3*n, 1);
+                permute(A, Ac, n, 4, 4);
+                kernel_tri_lo2hi_AVX_FMA(RP, 0, m, Ac, 4);
+                permute_t(A, Ac, n, 4, 4);
+                err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
+                permute(A, Ac, n, 4, 4);
+                kernel_tri_hi2lo_AVX(RP, 0, m, Ac, 4);
+                permute_t(A, Ac, n, 4, 4);
+                kernel_tri_lo2hi_default(RP, 0, m, A, 1);
+                kernel_tri_lo2hi_default(RP, 0, m+1, A+n, 1);
+                kernel_tri_lo2hi_default(RP, 0, m+2, A+2*n, 1);
+                kernel_tri_lo2hi_default(RP, 0, m+3, A+3*n, 1);
+                err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
+                permute(A, Ac, n, 4, 4);
+                kernel_tri_hi2lo_AVX_FMA(RP, 0, m, Ac, 4);
+                kernel_tri_lo2hi_AVX(RP, 0, m, Ac, 4);
+                permute_t(A, Ac, n, 4, 4);
+                err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
             }
-            for (int i = n-m; i < n; i++)
-                A[i] = A[i+n] = A[i+2*n] = A[i+3*n] = Ac[i] = Ac[i+n] = Ac[i+2*n] = Ac[i+3*n] = B[i] = B[i+n] = B[i+2*n] = B[i+3*n] = 0.0;
-            kernel_tri_hi2lo_default(RP, 0, m, A, 1);
-            kernel_tri_hi2lo_default(RP, 0, m+1, A+n, 1);
-            kernel_tri_hi2lo_default(RP, 0, m+2, A+2*n, 1);
-            kernel_tri_hi2lo_default(RP, 0, m+3, A+3*n, 1);
-            permute(A, Ac, n, 4, 4);
-            kernel_tri_lo2hi_AVX_FMA(RP, 0, m, Ac, 4);
-            permute_t(A, Ac, n, 4, 4);
-            err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
-            permute(A, Ac, n, 4, 4);
-            kernel_tri_hi2lo_AVX(RP, 0, m, Ac, 4);
-            permute_t(A, Ac, n, 4, 4);
-            kernel_tri_lo2hi_default(RP, 0, m, A, 1);
-            kernel_tri_lo2hi_default(RP, 0, m+1, A+n, 1);
-            kernel_tri_lo2hi_default(RP, 0, m+2, A+2*n, 1);
-            kernel_tri_lo2hi_default(RP, 0, m+3, A+3*n, 1);
-            err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
-            permute(A, Ac, n, 4, 4);
-            kernel_tri_hi2lo_AVX_FMA(RP, 0, m, Ac, 4);
-            kernel_tri_lo2hi_AVX(RP, 0, m, Ac, 4);
-            permute_t(A, Ac, n, 4, 4);
-            err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
-        }
-        err = sqrt(err);
-        printf("Applying the rotations with four  columns at n = %3i: \t |%20.2e ", n, err);
-        ft_checktest(err, 2*n, &checksum);
-        free(A);
-        VFREE(Ac);
-        free(B);
+            err = sqrt(err);
+            printf("Applying the rotations with four  columns at n = %3i: \t |%20.2e ", n, err);
+            ft_checktest(err, 2*n, &checksum);
+            free(A);
+            VFREE(Ac);
+            free(B);
 
-        err = 0;
-        A = calloc(8*n, sizeof(double));
-        Ac = VMALLOC(8*n*sizeof(double));
-        B = calloc(8*n, sizeof(double));
-        for (int m = 1; m < n; m++) {
-            for (int i = 0; i < n-m; i++) {
-                A[i] = Ac[i] = B[i] = 1.0;
-                A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
-                A[i+2*n] = Ac[i+2*n] = B[i+2*n] = 1.0/pow(i+1, 2);
-                A[i+3*n] = Ac[i+3*n] = B[i+3*n] = 1.0/pow(i+1, 3);
-                A[i+4*n] = Ac[i+4*n] = B[i+4*n] = 1.0/pow(i+1, 4);
-                A[i+5*n] = Ac[i+5*n] = B[i+5*n] = 1.0/pow(i+1, 5);
-                A[i+6*n] = Ac[i+6*n] = B[i+6*n] = 1.0/pow(i+1, 6);
-                A[i+7*n] = Ac[i+7*n] = B[i+7*n] = 1.0/pow(i+1, 7);
+            err = 0;
+            A = calloc(8*n, sizeof(double));
+            Ac = VMALLOC(8*n*sizeof(double));
+            B = calloc(8*n, sizeof(double));
+            for (int m = 1; m < n; m++) {
+                for (int i = 0; i < n-m; i++) {
+                    A[i] = Ac[i] = B[i] = 1.0;
+                    A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
+                    A[i+2*n] = Ac[i+2*n] = B[i+2*n] = 1.0/pow(i+1, 2);
+                    A[i+3*n] = Ac[i+3*n] = B[i+3*n] = 1.0/pow(i+1, 3);
+                    A[i+4*n] = Ac[i+4*n] = B[i+4*n] = 1.0/pow(i+1, 4);
+                    A[i+5*n] = Ac[i+5*n] = B[i+5*n] = 1.0/pow(i+1, 5);
+                    A[i+6*n] = Ac[i+6*n] = B[i+6*n] = 1.0/pow(i+1, 6);
+                    A[i+7*n] = Ac[i+7*n] = B[i+7*n] = 1.0/pow(i+1, 7);
+                }
+                for (int i = n-m; i < n; i++)
+                    A[i] = A[i+n] = A[i+2*n] = A[i+3*n] = A[i+4*n] = A[i+5*n] = A[i+6*n] = A[i+7*n] = Ac[i] = Ac[i+n] = Ac[i+2*n] = Ac[i+3*n] = Ac[i+4*n] = Ac[i+5*n] = Ac[i+6*n] = Ac[i+7*n] = B[i] = B[i+n] = B[i+2*n] = B[i+3*n] = B[i+4*n] = B[i+5*n] = B[i+6*n] = B[i+7*n] = 0.0;
+                kernel_tri_hi2lo_default(RP, 0, m, A, 1);
+                kernel_tri_hi2lo_default(RP, 0, m+1, A+n, 1);
+                kernel_tri_hi2lo_default(RP, 0, m+2, A+2*n, 1);
+                kernel_tri_hi2lo_default(RP, 0, m+3, A+3*n, 1);
+                kernel_tri_hi2lo_default(RP, 0, m+4, A+4*n, 1);
+                kernel_tri_hi2lo_default(RP, 0, m+5, A+5*n, 1);
+                kernel_tri_hi2lo_default(RP, 0, m+6, A+6*n, 1);
+                kernel_tri_hi2lo_default(RP, 0, m+7, A+7*n, 1);
+                permute(A, Ac, n, 8, 8);
+                kernel_tri_lo2hi_AVX512F(RP, 0, m, Ac, 8);
+                permute_t(A, Ac, n, 8, 8);
+                err += pow(ft_norm_2arg(A, B, 8*n)/ft_norm_1arg(B, 8*n), 2);
+                permute(A, Ac, n, 8, 8);
+                kernel_tri_hi2lo_AVX512F(RP, 0, m, Ac, 8);
+                permute_t(A, Ac, n, 8, 8);
+                kernel_tri_lo2hi_default(RP, 0, m, A, 1);
+                kernel_tri_lo2hi_default(RP, 0, m+1, A+n, 1);
+                kernel_tri_lo2hi_default(RP, 0, m+2, A+2*n, 1);
+                kernel_tri_lo2hi_default(RP, 0, m+3, A+3*n, 1);
+                kernel_tri_lo2hi_default(RP, 0, m+4, A+4*n, 1);
+                kernel_tri_lo2hi_default(RP, 0, m+5, A+5*n, 1);
+                kernel_tri_lo2hi_default(RP, 0, m+6, A+6*n, 1);
+                kernel_tri_lo2hi_default(RP, 0, m+7, A+7*n, 1);
+                err += pow(ft_norm_2arg(A, B, 8*n)/ft_norm_1arg(B, 8*n), 2);
             }
-            for (int i = n-m; i < n; i++)
-                A[i] = A[i+n] = A[i+2*n] = A[i+3*n] = A[i+4*n] = A[i+5*n] = A[i+6*n] = A[i+7*n] = Ac[i] = Ac[i+n] = Ac[i+2*n] = Ac[i+3*n] = Ac[i+4*n] = Ac[i+5*n] = Ac[i+6*n] = Ac[i+7*n] = B[i] = B[i+n] = B[i+2*n] = B[i+3*n] = B[i+4*n] = B[i+5*n] = B[i+6*n] = B[i+7*n] = 0.0;
-            kernel_tri_hi2lo_default(RP, 0, m, A, 1);
-            kernel_tri_hi2lo_default(RP, 0, m+1, A+n, 1);
-            kernel_tri_hi2lo_default(RP, 0, m+2, A+2*n, 1);
-            kernel_tri_hi2lo_default(RP, 0, m+3, A+3*n, 1);
-            kernel_tri_hi2lo_default(RP, 0, m+4, A+4*n, 1);
-            kernel_tri_hi2lo_default(RP, 0, m+5, A+5*n, 1);
-            kernel_tri_hi2lo_default(RP, 0, m+6, A+6*n, 1);
-            kernel_tri_hi2lo_default(RP, 0, m+7, A+7*n, 1);
-            permute(A, Ac, n, 8, 8);
-            kernel_tri_lo2hi_AVX512F(RP, 0, m, Ac, 8);
-            permute_t(A, Ac, n, 8, 8);
-            err += pow(ft_norm_2arg(A, B, 8*n)/ft_norm_1arg(B, 8*n), 2);
-            permute(A, Ac, n, 8, 8);
-            kernel_tri_hi2lo_AVX512F(RP, 0, m, Ac, 8);
-            permute_t(A, Ac, n, 8, 8);
-            kernel_tri_lo2hi_default(RP, 0, m, A, 1);
-            kernel_tri_lo2hi_default(RP, 0, m+1, A+n, 1);
-            kernel_tri_lo2hi_default(RP, 0, m+2, A+2*n, 1);
-            kernel_tri_lo2hi_default(RP, 0, m+3, A+3*n, 1);
-            kernel_tri_lo2hi_default(RP, 0, m+4, A+4*n, 1);
-            kernel_tri_lo2hi_default(RP, 0, m+5, A+5*n, 1);
-            kernel_tri_lo2hi_default(RP, 0, m+6, A+6*n, 1);
-            kernel_tri_lo2hi_default(RP, 0, m+7, A+7*n, 1);
-            err += pow(ft_norm_2arg(A, B, 8*n)/ft_norm_1arg(B, 8*n), 2);
-        }
-        err = sqrt(err);
-        printf("Applying the rotations with eight columns at n = %3i: \t |%20.2e ", n, err);
-        ft_checktest(err, 2*n, &checksum);
-        free(A);
-        VFREE(Ac);
-        free(B);
+            err = sqrt(err);
+            printf("Applying the rotations with eight columns at n = %3i: \t |%20.2e ", n, err);
+            ft_checktest(err, 2*n, &checksum);
+            free(A);
+            VFREE(Ac);
+            free(B);
+        #elif defined(__aarch64__)
+            err = 0;
+            A = calloc(2*n, sizeof(double));
+            Ac = VMALLOC(2*n*sizeof(double));
+            B = calloc(2*n, sizeof(double));
+            for (int m = 1; m < n; m++) {
+                for (int i = 0; i < n-m; i++) {
+                    A[i] = Ac[i] = B[i] = 1.0;
+                    A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
+                }
+                for (int i = n-m; i < n; i++)
+                    A[i] = A[i+n] = Ac[i] = Ac[i+n] = B[i] = B[i+n] = 0.0;
+                kernel_tri_hi2lo_default(RP, 0, m, A, 1);
+                kernel_tri_hi2lo_default(RP, 0, m+1, A+n, 1);
+                permute(A, Ac, n, 2, 2);
+                kernel_tri_lo2hi_NEON(RP, 0, m, Ac, 2);
+                permute_t(A, Ac, n, 2, 2);
+                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                permute(A, Ac, n, 2, 2);
+                kernel_tri_hi2lo_NEON(RP, 0, m, Ac, 2);
+                permute_t(A, Ac, n, 2, 2);
+                kernel_tri_lo2hi_default(RP, 0, m, A, 1);
+                kernel_tri_lo2hi_default(RP, 0, m+1, A+n, 1);
+                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+            }
+            err = sqrt(err);
+            printf("Applying the rotations with two   columns at n = %3i: \t |%20.2e ", n, err);
+            ft_checktest(err, 2*n, &checksum);
+            free(A);
+            VFREE(Ac);
+            free(B);
+        #endif
         ft_destroy_rotation_plan(RP);
     }
 
@@ -362,139 +404,160 @@ int main(void) {
         free(A);
         free(B);
 
-        err = 0;
-        A = calloc(2*n, sizeof(double));
-        Ac = VMALLOC(2*n*sizeof(double));
-        B = calloc(2*n, sizeof(double));
-        for (int m = 2; m < 2*n-1; m++) {
-            for (int i = 0; i < n-(m+1)/2; i++) {
-                A[i] = Ac[i] = B[i] = 1.0;
-                A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
+        #if defined(__i386__) || defined(__x86_64__)
+            err = 0;
+            A = calloc(2*n, sizeof(double));
+            Ac = VMALLOC(2*n*sizeof(double));
+            B = calloc(2*n, sizeof(double));
+            for (int m = 2; m < 2*n-1; m++) {
+                for (int i = 0; i < n-(m+1)/2; i++) {
+                    A[i] = Ac[i] = B[i] = 1.0;
+                    A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
+                }
+                for (int i = n-(m+1)/2; i < n; i++)
+                    A[i] = A[i+n] = Ac[i] = Ac[i+n] = B[i] = B[i+n] = 0.0;
+                kernel_disk_hi2lo_default(RP, m%2, m, A, 1);
+                kernel_disk_hi2lo_default(RP, m%2, m, A+n, 1);
+                permute(A, Ac, n, 2, 2);
+                kernel_disk_lo2hi_SSE2(RP, m%2, m, Ac, 2);
+                permute_t(A, Ac, n, 2, 2);
+                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                permute(A, Ac, n, 2, 2);
+                kernel_disk_hi2lo_SSE2(RP, m%2, m, Ac, 2);
+                permute_t(A, Ac, n, 2, 2);
+                kernel_disk_lo2hi_default(RP, m%2, m, A, 1);
+                kernel_disk_lo2hi_default(RP, m%2, m, A+n, 1);
+                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
             }
-            for (int i = n-(m+1)/2; i < n; i++)
-                A[i] = A[i+n] = Ac[i] = Ac[i+n] = B[i] = B[i+n] = 0.0;
-            kernel_disk_hi2lo_default(RP, m%2, m, A, 1);
-            kernel_disk_hi2lo_default(RP, m%2, m, A+n, 1);
-            permute(A, Ac, n, 2, 2);
-            kernel_disk_lo2hi_SSE2(RP, m%2, m, Ac, 2);
-            permute_t(A, Ac, n, 2, 2);
-            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-            permute(A, Ac, n, 2, 2);
-            kernel_disk_hi2lo_SSE2(RP, m%2, m, Ac, 2);
-            permute_t(A, Ac, n, 2, 2);
-            kernel_disk_lo2hi_default(RP, m%2, m, A, 1);
-            kernel_disk_lo2hi_default(RP, m%2, m, A+n, 1);
-            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-            kernel_disk_hi2lo_default(RP, m%2, m, A, 1);
-            kernel_disk_hi2lo_default(RP, m%2, m, A+n, 1);
-            permute(A, Ac, n, 2, 2);
-            kernel_disk_lo2hi_NEON(RP, m%2, m, Ac, 2);
-            permute_t(A, Ac, n, 2, 2);
-            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-            permute(A, Ac, n, 2, 2);
-            kernel_disk_hi2lo_NEON(RP, m%2, m, Ac, 2);
-            permute_t(A, Ac, n, 2, 2);
-            kernel_disk_lo2hi_default(RP, m%2, m, A, 1);
-            kernel_disk_lo2hi_default(RP, m%2, m, A+n, 1);
-            err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-        }
-        err = sqrt(err);
-        printf("Applying the rotations with two   columns at n = %3i: \t |%20.2e ", n, err);
-        ft_checktest(err, 3*n, &checksum);
-        free(A);
-        VFREE(Ac);
-        free(B);
+            err = sqrt(err);
+            printf("Applying the rotations with two   columns at n = %3i: \t |%20.2e ", n, err);
+            ft_checktest(err, 2*n, &checksum);
+            free(A);
+            VFREE(Ac);
+            free(B);
 
-        err = 0;
-        A = calloc(4*n, sizeof(double));
-        Ac = VMALLOC(4*n*sizeof(double));
-        B = calloc(4*n, sizeof(double));
-        for (int m = 2; m < 2*n-1; m++) {
-            for (int i = 0; i < n-(m+1)/2; i++) {
-                A[i] = Ac[i] = B[i] = 1.0;
-                A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
-                A[i+2*n] = Ac[i+2*n] = B[i+2*n] = 1.0/pow(i+1, 2);
-                A[i+3*n] = Ac[i+3*n] = B[i+3*n] = 1.0/pow(i+1, 3);
+            err = 0;
+            A = calloc(4*n, sizeof(double));
+            Ac = VMALLOC(4*n*sizeof(double));
+            B = calloc(4*n, sizeof(double));
+            for (int m = 2; m < 2*n-1; m++) {
+                for (int i = 0; i < n-(m+1)/2; i++) {
+                    A[i] = Ac[i] = B[i] = 1.0;
+                    A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
+                    A[i+2*n] = Ac[i+2*n] = B[i+2*n] = 1.0/pow(i+1, 2);
+                    A[i+3*n] = Ac[i+3*n] = B[i+3*n] = 1.0/pow(i+1, 3);
+                }
+                for (int i = n-(m+1)/2; i < n; i++)
+                    A[i] = A[i+n] = A[i+2*n] = A[i+3*n] = Ac[i] = Ac[i+n] = Ac[i+2*n] = Ac[i+3*n] = B[i] = B[i+n] = B[i+2*n] = B[i+3*n] = 0.0;
+                kernel_disk_hi2lo_default(RP, m%2, m, A, 1);
+                kernel_disk_hi2lo_default(RP, m%2, m, A+n, 1);
+                kernel_disk_hi2lo_default(RP, m%2, m+2, A+2*n, 1);
+                kernel_disk_hi2lo_default(RP, m%2, m+2, A+3*n, 1);
+                permute(A, Ac, n, 4, 4);
+                kernel_disk_lo2hi_AVX_FMA(RP, m%2, m, Ac, 4);
+                permute_t(A, Ac, n, 4, 4);
+                err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
+                permute(A, Ac, n, 4, 4);
+                kernel_disk_hi2lo_AVX(RP, m%2, m, Ac, 4);
+                permute_t(A, Ac, n, 4, 4);
+                kernel_disk_lo2hi_default(RP, m%2, m, A, 1);
+                kernel_disk_lo2hi_default(RP, m%2, m, A+n, 1);
+                kernel_disk_lo2hi_default(RP, m%2, m+2, A+2*n, 1);
+                kernel_disk_lo2hi_default(RP, m%2, m+2, A+3*n, 1);
+                err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
+                permute(A, Ac, n, 4, 4);
+                kernel_disk_hi2lo_AVX_FMA(RP, m%2, m, Ac, 4);
+                kernel_disk_lo2hi_AVX(RP, m%2, m, Ac, 4);
+                permute_t(A, Ac, n, 4, 4);
+                err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
             }
-            for (int i = n-(m+1)/2; i < n; i++)
-                A[i] = A[i+n] = A[i+2*n] = A[i+3*n] = Ac[i] = Ac[i+n] = Ac[i+2*n] = Ac[i+3*n] = B[i] = B[i+n] = B[i+2*n] = B[i+3*n] = 0.0;
-            kernel_disk_hi2lo_default(RP, m%2, m, A, 1);
-            kernel_disk_hi2lo_default(RP, m%2, m, A+n, 1);
-            kernel_disk_hi2lo_default(RP, m%2, m+2, A+2*n, 1);
-            kernel_disk_hi2lo_default(RP, m%2, m+2, A+3*n, 1);
-            permute(A, Ac, n, 4, 4);
-            kernel_disk_lo2hi_AVX_FMA(RP, m%2, m, Ac, 4);
-            permute_t(A, Ac, n, 4, 4);
-            err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
-            permute(A, Ac, n, 4, 4);
-            kernel_disk_hi2lo_AVX(RP, m%2, m, Ac, 4);
-            permute_t(A, Ac, n, 4, 4);
-            kernel_disk_lo2hi_default(RP, m%2, m, A, 1);
-            kernel_disk_lo2hi_default(RP, m%2, m, A+n, 1);
-            kernel_disk_lo2hi_default(RP, m%2, m+2, A+2*n, 1);
-            kernel_disk_lo2hi_default(RP, m%2, m+2, A+3*n, 1);
-            err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
-            permute(A, Ac, n, 4, 4);
-            kernel_disk_hi2lo_AVX_FMA(RP, m%2, m, Ac, 4);
-            kernel_disk_lo2hi_AVX(RP, m%2, m, Ac, 4);
-            permute_t(A, Ac, n, 4, 4);
-            err += pow(ft_norm_2arg(A, B, 4*n)/ft_norm_1arg(B, 4*n), 2);
-        }
-        err = sqrt(err);
-        printf("Applying the rotations with four  columns at n = %3i: \t |%20.2e ", n, err);
-        ft_checktest(err, 2*n, &checksum);
-        free(A);
-        VFREE(Ac);
-        free(B);
+            err = sqrt(err);
+            printf("Applying the rotations with four  columns at n = %3i: \t |%20.2e ", n, err);
+            ft_checktest(err, 2*n, &checksum);
+            free(A);
+            VFREE(Ac);
+            free(B);
 
-        err = 0;
-        A = calloc(8*n, sizeof(double));
-        Ac = VMALLOC(8*n*sizeof(double));
-        B = calloc(8*n, sizeof(double));
-        for (int m = 2; m < 2*n-1; m++) {
-            for (int i = 0; i < n-(m+1)/2; i++) {
-                A[i] = Ac[i] = B[i] = 1.0;
-                A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
-                A[i+2*n] = Ac[i+2*n] = B[i+2*n] = 1.0/pow(i+1, 2);
-                A[i+3*n] = Ac[i+3*n] = B[i+3*n] = 1.0/pow(i+1, 3);
-                A[i+4*n] = Ac[i+4*n] = B[i+4*n] = 1.0/pow(i+1, 4);
-                A[i+5*n] = Ac[i+5*n] = B[i+5*n] = 1.0/pow(i+1, 5);
-                A[i+6*n] = Ac[i+6*n] = B[i+6*n] = 1.0/pow(i+1, 6);
-                A[i+7*n] = Ac[i+7*n] = B[i+7*n] = 1.0/pow(i+1, 7);
+            err = 0;
+            A = calloc(8*n, sizeof(double));
+            Ac = VMALLOC(8*n*sizeof(double));
+            B = calloc(8*n, sizeof(double));
+            for (int m = 2; m < 2*n-1; m++) {
+                for (int i = 0; i < n-(m+1)/2; i++) {
+                    A[i] = Ac[i] = B[i] = 1.0;
+                    A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
+                    A[i+2*n] = Ac[i+2*n] = B[i+2*n] = 1.0/pow(i+1, 2);
+                    A[i+3*n] = Ac[i+3*n] = B[i+3*n] = 1.0/pow(i+1, 3);
+                    A[i+4*n] = Ac[i+4*n] = B[i+4*n] = 1.0/pow(i+1, 4);
+                    A[i+5*n] = Ac[i+5*n] = B[i+5*n] = 1.0/pow(i+1, 5);
+                    A[i+6*n] = Ac[i+6*n] = B[i+6*n] = 1.0/pow(i+1, 6);
+                    A[i+7*n] = Ac[i+7*n] = B[i+7*n] = 1.0/pow(i+1, 7);
+                }
+                for (int i = n-(m+1)/2; i < n; i++)
+                    A[i] = A[i+n] = A[i+2*n] = A[i+3*n] = A[i+4*n] = A[i+5*n] = A[i+6*n] = A[i+7*n] = Ac[i] = Ac[i+n] = Ac[i+2*n] = Ac[i+3*n] = Ac[i+4*n] = Ac[i+5*n] = Ac[i+6*n] = Ac[i+7*n] = B[i] = B[i+n] = B[i+2*n] = B[i+3*n] = B[i+4*n] = B[i+5*n] = B[i+6*n] = B[i+7*n] = 0.0;
+                kernel_disk_hi2lo_default(RP, m%2, m, A, 1);
+                kernel_disk_hi2lo_default(RP, m%2, m, A+n, 1);
+                kernel_disk_hi2lo_default(RP, m%2, m+2, A+2*n, 1);
+                kernel_disk_hi2lo_default(RP, m%2, m+2, A+3*n, 1);
+                kernel_disk_hi2lo_default(RP, m%2, m+4, A+4*n, 1);
+                kernel_disk_hi2lo_default(RP, m%2, m+4, A+5*n, 1);
+                kernel_disk_hi2lo_default(RP, m%2, m+6, A+6*n, 1);
+                kernel_disk_hi2lo_default(RP, m%2, m+6, A+7*n, 1);
+                permute(A, Ac, n, 8, 8);
+                kernel_disk_lo2hi_AVX512F(RP, m%2, m, Ac, 8);
+                permute_t(A, Ac, n, 8, 8);
+                err += pow(ft_norm_2arg(A, B, 8*n)/ft_norm_1arg(B, 8*n), 2);
+                permute(A, Ac, n, 8, 8);
+                kernel_disk_hi2lo_AVX512F(RP, m%2, m, Ac, 8);
+                permute_t(A, Ac, n, 8, 8);
+                kernel_disk_lo2hi_default(RP, m%2, m, A, 1);
+                kernel_disk_lo2hi_default(RP, m%2, m, A+n, 1);
+                kernel_disk_lo2hi_default(RP, m%2, m+2, A+2*n, 1);
+                kernel_disk_lo2hi_default(RP, m%2, m+2, A+3*n, 1);
+                kernel_disk_lo2hi_default(RP, m%2, m+4, A+4*n, 1);
+                kernel_disk_lo2hi_default(RP, m%2, m+4, A+5*n, 1);
+                kernel_disk_lo2hi_default(RP, m%2, m+6, A+6*n, 1);
+                kernel_disk_lo2hi_default(RP, m%2, m+6, A+7*n, 1);
+                err += pow(ft_norm_2arg(A, B, 8*n)/ft_norm_1arg(B, 8*n), 2);
             }
-            for (int i = n-(m+1)/2; i < n; i++)
-                A[i] = A[i+n] = A[i+2*n] = A[i+3*n] = A[i+4*n] = A[i+5*n] = A[i+6*n] = A[i+7*n] = Ac[i] = Ac[i+n] = Ac[i+2*n] = Ac[i+3*n] = Ac[i+4*n] = Ac[i+5*n] = Ac[i+6*n] = Ac[i+7*n] = B[i] = B[i+n] = B[i+2*n] = B[i+3*n] = B[i+4*n] = B[i+5*n] = B[i+6*n] = B[i+7*n] = 0.0;
-            kernel_disk_hi2lo_default(RP, m%2, m, A, 1);
-            kernel_disk_hi2lo_default(RP, m%2, m, A+n, 1);
-            kernel_disk_hi2lo_default(RP, m%2, m+2, A+2*n, 1);
-            kernel_disk_hi2lo_default(RP, m%2, m+2, A+3*n, 1);
-            kernel_disk_hi2lo_default(RP, m%2, m+4, A+4*n, 1);
-            kernel_disk_hi2lo_default(RP, m%2, m+4, A+5*n, 1);
-            kernel_disk_hi2lo_default(RP, m%2, m+6, A+6*n, 1);
-            kernel_disk_hi2lo_default(RP, m%2, m+6, A+7*n, 1);
-            permute(A, Ac, n, 8, 8);
-            kernel_disk_lo2hi_AVX512F(RP, m%2, m, Ac, 8);
-            permute_t(A, Ac, n, 8, 8);
-            err += pow(ft_norm_2arg(A, B, 8*n)/ft_norm_1arg(B, 8*n), 2);
-            permute(A, Ac, n, 8, 8);
-            kernel_disk_hi2lo_AVX512F(RP, m%2, m, Ac, 8);
-            permute_t(A, Ac, n, 8, 8);
-            kernel_disk_lo2hi_default(RP, m%2, m, A, 1);
-            kernel_disk_lo2hi_default(RP, m%2, m, A+n, 1);
-            kernel_disk_lo2hi_default(RP, m%2, m+2, A+2*n, 1);
-            kernel_disk_lo2hi_default(RP, m%2, m+2, A+3*n, 1);
-            kernel_disk_lo2hi_default(RP, m%2, m+4, A+4*n, 1);
-            kernel_disk_lo2hi_default(RP, m%2, m+4, A+5*n, 1);
-            kernel_disk_lo2hi_default(RP, m%2, m+6, A+6*n, 1);
-            kernel_disk_lo2hi_default(RP, m%2, m+6, A+7*n, 1);
-            err += pow(ft_norm_2arg(A, B, 8*n)/ft_norm_1arg(B, 8*n), 2);
-        }
-        err = sqrt(err);
-        printf("Applying the rotations with eight columns at n = %3i: \t |%20.2e ", n, err);
-        ft_checktest(err, 2*n, &checksum);
-        free(A);
-        VFREE(Ac);
-        free(B);
+            err = sqrt(err);
+            printf("Applying the rotations with eight columns at n = %3i: \t |%20.2e ", n, err);
+            ft_checktest(err, 2*n, &checksum);
+            free(A);
+            VFREE(Ac);
+            free(B);
+        #elif defined(__aarch64__)
+            err = 0;
+            A = calloc(2*n, sizeof(double));
+            Ac = VMALLOC(2*n*sizeof(double));
+            B = calloc(2*n, sizeof(double));
+            for (int m = 2; m < 2*n-1; m++) {
+                for (int i = 0; i < n-(m+1)/2; i++) {
+                    A[i] = Ac[i] = B[i] = 1.0;
+                    A[i+n] = Ac[i+n] = B[i+n] = 1.0/(i+1);
+                }
+                for (int i = n-(m+1)/2; i < n; i++)
+                    A[i] = A[i+n] = Ac[i] = Ac[i+n] = B[i] = B[i+n] = 0.0;
+                kernel_disk_hi2lo_default(RP, m%2, m, A, 1);
+                kernel_disk_hi2lo_default(RP, m%2, m, A+n, 1);
+                permute(A, Ac, n, 2, 2);
+                kernel_disk_lo2hi_NEON(RP, m%2, m, Ac, 2);
+                permute_t(A, Ac, n, 2, 2);
+                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                permute(A, Ac, n, 2, 2);
+                kernel_disk_hi2lo_NEON(RP, m%2, m, Ac, 2);
+                permute_t(A, Ac, n, 2, 2);
+                kernel_disk_lo2hi_default(RP, m%2, m, A, 1);
+                kernel_disk_lo2hi_default(RP, m%2, m, A+n, 1);
+                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+            }
+            err = sqrt(err);
+            printf("Applying the rotations with two   columns at n = %3i: \t |%20.2e ", n, err);
+            ft_checktest(err, 2*n, &checksum);
+            free(A);
+            VFREE(Ac);
+            free(B);
+        #endif
         ft_destroy_rotation_plan(RP);
     }
 
@@ -518,18 +581,21 @@ int main(void) {
                     A[2*i] = A[2*i+1] = B[2*i] = B[2*i+1] = 1.0;
                 for (int i = n-MAX(am, as); i < n; i++)
                     A[2*i] = A[2*i+1] = B[2*i] = B[2*i+1] = 0.0;
-                kernel_spinsph_hi2lo_default(SRP, m, AC, 1);
-                kernel_spinsph_lo2hi_SSE2(SRP, m, AC, 1);
-                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-                kernel_spinsph_hi2lo_SSE2(SRP, m, AC, 1);
-                kernel_spinsph_lo2hi_default(SRP, m, AC, 1);
-                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-                kernel_spinsph_hi2lo_default(SRP, m, AC, 1);
-                kernel_spinsph_lo2hi_NEON(SRP, m, AC, 1);
-                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-                kernel_spinsph_hi2lo_NEON(SRP, m, AC, 1);
-                kernel_spinsph_lo2hi_default(SRP, m, AC, 1);
-                err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                #if defined(__i386__) || defined(__x86_64__)
+                    kernel_spinsph_hi2lo_default(SRP, m, AC, 1);
+                    kernel_spinsph_lo2hi_SSE2(SRP, m, AC, 1);
+                    err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                    kernel_spinsph_hi2lo_SSE2(SRP, m, AC, 1);
+                    kernel_spinsph_lo2hi_default(SRP, m, AC, 1);
+                    err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                #elif defined(__aarch64__)
+                    kernel_spinsph_hi2lo_default(SRP, m, AC, 1);
+                    kernel_spinsph_lo2hi_NEON(SRP, m, AC, 1);
+                    err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                    kernel_spinsph_hi2lo_NEON(SRP, m, AC, 1);
+                    kernel_spinsph_lo2hi_default(SRP, m, AC, 1);
+                    err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                #endif
                 if (s == 0) {
                     kernel_spinsph_hi2lo_default(SRP, m, AC, 1);
                     kernel_sph_lo2hi_default(RP, am%2, am, A, 2);
@@ -539,28 +605,31 @@ int main(void) {
                     kernel_sph_hi2lo_default(RP, am%2, am, A+1, 2);
                     kernel_spinsph_lo2hi_default(SRP, m, AC, 1);
                     err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-                    kernel_sph_hi2lo_default(RP, am%2, am, A, 2);
-                    kernel_sph_hi2lo_default(RP, am%2, am, A+1, 2);
-                    kernel_spinsph_lo2hi_SSE2(SRP, m, AC, 1);
-                    err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-                    kernel_spinsph_hi2lo_SSE2(SRP, m, AC, 1);
-                    kernel_sph_lo2hi_default(RP, am%2, am, A, 2);
-                    kernel_sph_lo2hi_default(RP, am%2, am, A+1, 2);
-                    err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-                    kernel_sph_hi2lo_default(RP, am%2, am, A, 2);
-                    kernel_sph_hi2lo_default(RP, am%2, am, A+1, 2);
-                    kernel_spinsph_lo2hi_NEON(SRP, m, AC, 1);
-                    err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
-                    kernel_spinsph_hi2lo_NEON(SRP, m, AC, 1);
-                    kernel_sph_lo2hi_default(RP, am%2, am, A, 2);
-                    kernel_sph_lo2hi_default(RP, am%2, am, A+1, 2);
-                    err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                    #if defined(__i386__) || defined(__x86_64__)
+                        kernel_sph_hi2lo_default(RP, am%2, am, A, 2);
+                        kernel_sph_hi2lo_default(RP, am%2, am, A+1, 2);
+                        kernel_spinsph_lo2hi_SSE2(SRP, m, AC, 1);
+                        err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                        kernel_spinsph_hi2lo_SSE2(SRP, m, AC, 1);
+                        kernel_sph_lo2hi_default(RP, am%2, am, A, 2);
+                        kernel_sph_lo2hi_default(RP, am%2, am, A+1, 2);
+                        err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                    #elif defied(__aarch64__)
+                        kernel_sph_hi2lo_default(RP, am%2, am, A, 2);
+                        kernel_sph_hi2lo_default(RP, am%2, am, A+1, 2);
+                        kernel_spinsph_lo2hi_NEON(SRP, m, AC, 1);
+                        err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                        kernel_spinsph_hi2lo_NEON(SRP, m, AC, 1);
+                        kernel_sph_lo2hi_default(RP, am%2, am, A, 2);
+                        kernel_sph_lo2hi_default(RP, am%2, am, A+1, 2);
+                        err += pow(ft_norm_2arg(A, B, 2*n)/ft_norm_1arg(B, 2*n), 2);
+                    #endif
                 }
             }
-            if (s == 0) err /= 9.0;
+            if (s == 0) err /= 6.0;
             err = sqrt(err);
             printf("Applying the rotations with spin s = %2i at n = %3i: \t |%20.2e ", s, n, err);
-            ft_checktest(err, 3*n, &checksum);
+            ft_checktest(err, 2*n, &checksum);
             free(A);
             free(B);
             ft_destroy_rotation_plan(RP);


### PR DESCRIPTION
The SIMD required here is predominately double precision, so this invokes NEON on armv8-a, which is always available. This isn't applicable for armv7, though that distinction could be made later.

Also adds missing fallbacks for AVX and AVX_FMA spin-weighted spherical harmonic computational kernels.