### PR TITLE
Slight performance improvement for spherical harmonic rotations

### DIFF
--- a/src/recurrence/recurrence.h
+++ b/src/recurrence/recurrence.h
@@ -123,13 +123,17 @@ for (; j < m+1-S*L; j += S*L) {                                                \
         X[l] = VLOAD(x+j+S*l);                                                 \
     }                                                                          \
     for (int k = n-1; k > 0; k--) {                                            \
+        VT nrmsum = VALL(0);                                                   \
         for (int l = 0; l < L; l++) {                                          \
             vkm1[l] = VALL(A[k])*VMULADD(X[l]+VALL(B[k]), vk[l], VALL(C[k])*vkp1[l]); \
             vkp1[l] = vk[l];                                                   \
             vk[l] = vkm1[l];                                                   \
             nrm[l] = VMULADD(vkm1[l], vkm1[l], nrm[l]);                        \
+            nrmsum += nrm[l];                                                  \
             sum[l] = VMULADD(vkm1[l], VALL(c[(k-1)*incc]), sum[l]);            \
-            if (VMOVEMASK(nrm[l] > VALL(HUGE)) != 0) {                         \
+        }                                                                      \
+        if (VMOVEMASK(nrmsum > VALL(HUGE)) != 0) {                             \
+            for (int l = 0; l < L; l++) {                                      \
                 nrm[l] = VALL(ONE)/VSQRT(nrm[l]);                              \
                 vkp1[l] = nrm[l]*vkp1[l];                                      \
                 vk[l] = nrm[l]*vk[l];                                          \


### PR DESCRIPTION
This patch re-organizes the central loop in such a way that fewer "movemask" operations are necessary (and the total number of branches is reduced).
Strictly speaking the code now normalizes a bit more often than necessary; the optimal way would be not to use the sum of the individual `nrm` components but their maximum. Overall I don't think this will make a measurable difference though.

On my computer the patch results in roughly 10% speedup at large band limits.
